### PR TITLE
Set tag for 1.0.0 rockspec

### DIFF
--- a/launchdarkly-server-sdk-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-1.0-0.rockspec
@@ -3,7 +3,8 @@ package = "launchdarkly-server-sdk"
 version = "1.0-0"
 
 source = {
-   url = "git+https://github.com/launchdarkly/lua-server-sdk.git"
+   url = "git+https://github.com/launchdarkly/lua-server-sdk.git",
+   tag = "1.0.0"
 }
 
 dependencies = {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

None applicable.

**Describe the solution you've provided**

There is a bug in the 1.0.0 rockspec where it doesn't install version 1.0.0, rather it actually installs the latest version of the library from master. This caused a CI failure for us, since we pinned the version of the LD C API as well as the version of the LD Lua server SDK, but since the Lua server SDK was secretly rolling-release, things got out of sync due to an update here.

<details>
<summary>Before my change</summary>

```
# luarocks LUA_INCDIR=/usr/include install https://raw.githubusercontent.com/launchdarkly/lua-server-sdk/master/launchdarkly-server-sdk-1.0-0.rockspec
Warning: The directory '/root/.cache/luarocks' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing /usr/bin/luarocks with sudo, you may want sudo's -H flag.
Cloning into 'lua-server-sdk'...
remote: Enumerating objects: 151, done.
remote: Counting objects: 100% (151/151), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 151 (delta 67), reused 121 (delta 45), pack-reused 0
Receiving objects: 100% (151/151), 78.45 KiB | 779.00 KiB/s, done.
Resolving deltas: 100% (67/67), done.
gcc -O2 -fPIC -I/usr/include -c launchdarkly-server-sdk.c -o launchdarkly-server-sdk.o -I/usr/local/include
launchdarkly-server-sdk.c: In function 'LuaLDClientAlias':
launchdarkly-server-sdk.c:1086:10: warning: implicit declaration of function 'LDClientAlias'; did you mean 'LuaLDClientAlias'? [-Wimplicit-function-declaration]
 1086 |     if (!LDClientAlias(*client, *currentUser, *previousUser)) {
      |          ^~~~~~~~~~~~~
      |          LuaLDClientAlias
gcc -shared -o launchdarkly_server_sdk.so -L/usr/lib launchdarkly-server-sdk.o -L/usr/local/lib -Wl,-rpath,/usr/local/lib: -lldserverapi
launchdarkly-server-sdk 1.0-0 is now installed in /usr/local
```

</details>

<details>
<summary>After my change</summary>

```
# luarocks LUA_INCDIR=/usr/include install https://raw.githubusercontent.com/raxod502-plaid/lua-server-sdk/make-install-actually-versioned/launchdarkly-server-sdk-1.0-0.rockspec
Warning: The directory '/root/.cache/luarocks' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing /usr/bin/luarocks with sudo, you may want sudo's -H flag.
Cloning into 'lua-server-sdk'...
remote: Enumerating objects: 151, done.
remote: Counting objects: 100% (151/151), done.
remote: Compressing objects: 100% (96/96), done.
remote: Total 151 (delta 67), reused 120 (delta 44), pack-reused 0
Receiving objects: 100% (151/151), 78.50 KiB | 427.00 KiB/s, done.
Resolving deltas: 100% (67/67), done.
Note: switching to '1320291f63fc3a28d0a7fce6b19ee96729ba9510'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

gcc -O2 -fPIC -I/usr/include -c launchdarkly-server-sdk.c -o launchdarkly-server-sdk.o -I/usr/local/include
gcc -shared -o launchdarkly_server_sdk.so -L/usr/lib launchdarkly-server-sdk.o -L/usr/local/lib -Wl,-rpath,/usr/local/lib: -lldserverapi
launchdarkly-server-sdk 1.0-0 is now installed in /usr/local
```

</details>

**Describe alternatives you've considered**

I have not considered any alternatives.

**Additional context**

None.
