### PR TITLE
ci: fix docs publishing workflow

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -4,6 +4,9 @@ description: 'Build Documentation.'
 runs:
   using: composite
   steps:
+    - name: Install LDoc
+      shell: bash
+      run: sudo apt-get update -y && sudo apt-get install -y lua-ldoc
     - name: Build Documentation
       shell: bash
       run: ./scripts/build-docs.sh docs

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -9,4 +9,4 @@ runs:
       run: sudo apt-get update -y && sudo apt-get install -y lua-ldoc
     - name: Build Documentation
       shell: bash
-      run: ./scripts/build-docs.sh docs
+      run: ./scripts/build-docs.sh docs-build docs-release

--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -11,5 +11,5 @@ runs:
     - uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.1
       name: 'Publish to Github pages'
       with:
-        docs_path: docs
+        docs_path: docs-release
         github_token: ${{ inputs.token }}

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Build and Test
         uses: ./.github/actions/ci
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           lua-version: "5.3"
 
       - name: Build documentation

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -15,6 +15,7 @@ jobs:
         uses: ./.github/actions/ci
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          lua-version: "5.3"
 
       - name: Build documentation
         uses: ./.github/actions/build-docs

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -3,16 +3,19 @@
 set -e
 
 # The first argument is the directory where the docs should be built.
+# The second is where the docs should be copied to when built.
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <docs-build-dir>"
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <docs build dir> <docs release dir>"
     exit 1
 fi
 
 DOCS_BUILD_DIR=$1
+DOCS_RELEASE_DIR=$2
+
 mkdir "$DOCS_BUILD_DIR"
 
 cp launchdarkly-server-sdk.c "$DOCS_BUILD_DIR"
 cp launchdarkly-server-sdk-redis.c "$DOCS_BUILD_DIR"
 
-ldoc -d "$LD_RELEASE_DOCS_DIR" "$DOCS_BUILD_DIR"
+ldoc -d "$DOCS_RELEASE_DIR" "$DOCS_BUILD_DIR"


### PR DESCRIPTION
Adds missing `luaVersion` workflow parameter to manual-build-docs. Also ensures `ldoc` is install on the CI runner.