### PR TITLE
feat!: use C++ Server-side SDK 3.0 bindings [v2]

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Run Lua Server-side SDK with Redis Tests (JIT)
       shell: bash
       if: ${{ contains(inputs.lua-version, 'jit') }}
-      run: luajit redis-test.lua
+      run: luajit test-redis.lua
       env:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Install CPP SDK
       uses: ./.github/actions/install-cpp-sdk-redis
       with:
-          version: redis-source-v1.1.0
+          version: launchdarkly-cpp-server-redis-source-v2.0.0
           path: cpp-sdk
 
     - name: Build Lua Server-side SDK

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -30,15 +30,13 @@ runs:
       shell: bash
       run:  |
         luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
-        LD_DIR=./cpp-sdk/build-dynamic/release \
-        BOOST_DIR=${{ steps.install-boost.outputs.BOOST_ROOT }}
+        LD_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Build Lua Server-side SDK with Redis
       shell: bash
       run: |
         luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
-        LDREDIS_DIR=./cpp-sdk/build-dynamic/release \
-        BOOST_DIR=${{ steps.install-boost.outputs.BOOST_ROOT }}
+        LDREDIS_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Run Lua Server-side SDK Tests
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -25,11 +25,6 @@ runs:
       with:
           version: redis-source-bindings-v1.1.0
           path: cpp-sdk
-    - name: Install C++ Server-side SDK Dependencies
-      shell: bash
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libhiredis-dev
 
     - name: Build Lua Server-side SDK
       shell: bash
@@ -43,7 +38,6 @@ runs:
       run: |
         luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release \
-        LD_DIR=./cpp-sdk/build-dynamic/release \
         BOOST_DIR=${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Run Lua Server-side SDK Tests
@@ -70,8 +64,9 @@ runs:
       run: luarocks test launchdarkly-server-sdk-redis-1.0-0.rockspec
       env:
         # Needed because boost isn't installed in default system paths, which is
-        # what the C++ Server-side SDK shared objec expects.
-        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
+        # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled
+        # with the SDK release.
+        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
 
     - name: Run Lua Server-side SDK with Redis Tests (JIT)
       shell: bash
@@ -79,5 +74,6 @@ runs:
       run: luajit redis-test.lua
       env:
         # Needed because boost isn't installed in default system paths, which is
-        # what the C++ Server-side SDK shared object expects.
-        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
+        # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled
+        # with the SDK release.
+        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Install CPP SDK
       uses: ./.github/actions/install-cpp-sdk-redis
       with:
-          version: launchdarkly-cpp-server-redis-source-v2.0.0
+          version: launchdarkly-cpp-server-redis-source-v2.1.0
           path: cpp-sdk
 
     - name: Build Lua Server-side SDK

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Install CPP SDK
       uses: ./.github/actions/install-cpp-sdk-redis
       with:
-          version: redis-source-bindings-v1.1.0
+          version: redis-source-v1.1.0
           path: cpp-sdk
 
     - name: Build Lua Server-side SDK
@@ -46,7 +46,7 @@ runs:
       run: luarocks test launchdarkly-server-sdk-1.0-0.rockspec
       env:
         # Needed because boost isn't installed in default system paths, which is
-        # what the C++ Server-side SDK shared objec expects.
+        # what the C++ Server-side SDK shared object expects.
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
 
     - name: Run Lua Server-side SDK Tests (JIT)

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -44,8 +44,7 @@ runs:
         luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release \
         LD_DIR=./cpp-sdk/build-dynamic/release \
-        BOOST_DIR=${{ steps.install-boost.outputs.BOOST_ROOT }} \
-        HIREDIS_DIR=./cpp-sdk/build-dynamic/release 
+        BOOST_DIR=${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Run Lua Server-side SDK Tests
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+cpp-sdks
+*.o
+*.so

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Supported C server-side SDK versions
 This version of the Lua server-side SDK depends on the C++ server-side SDK C bindings, as well as the 
 C++ server-side SDK's Redis source integration.
 
-The minimum required version is `1.0.0` for the Redis source.
+The minimum required version is `2.0.0` for the Redis source.
 
 
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ To compile the LuaRock modules:
 1. Install [LuaRocks](https://github.com/luarocks/luarocks/wiki/Download)
 2. Build the [C++ Server-side SDK](https://github.com/launchdarkly/cpp-sdks) from source using CMake, or obtain pre-built artifacts from the [releases page](https://github.com/launchdarkly/cpp-sdks/releases?q=%22launchdarkly-cpp-server%22)
 3. Run `luarocks make`:
-```bash
-# Base SDK
-luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
-LD_DIR=./path-to-installed-cpp-sdk
+    ```bash
+    # Base SDK
+    luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
+    LD_DIR=./path-to-installed-cpp-sdk
 
-# SDK with Redis
-luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
-LDREDIS_DIR=./path-to-installed-cpp-sdk
-```
+    # SDK with Redis
+    luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
+    LDREDIS_DIR=./path-to-installed-cpp-sdk
+    ```
 
 Please note that the Lua SDK uses the C++ server-side SDK's C bindings, so if you're using prebuilt artifacts
 then only a C99 compiler is necessary.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Supported C server-side SDK versions
 This version of the Lua server-side SDK depends on the C++ server-side SDK C bindings, as well as the 
 C++ server-side SDK's Redis source integration.
 
-The minimum required version is `2.0.0` for the Redis source.
+The minimum required version is `2.1.0` for the Redis source.
 
 
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,56 @@ LaunchDarkly overview
 Supported Lua versions
 -----------
 
-This version of the LaunchDarkly SDK is compatible with the Lua 5.1-5.3 interpreter, and LuaJIT.
+This version of the LaunchDarkly SDK is known to be compatible with the Lua 5.1-5.3 interpreter, and LuaJIT 2.0.5.
 
-Supported C server-side SDK versions
+Supported C++ server-side SDK versions
 -----------
 
-This version of the Lua server-side SDK depends on the C++ server-side SDK C bindings, as well as the 
-C++ server-side SDK's Redis source integration.
+This version of the Lua server-side SDK depends on the LaunchDarkly C++ Server-side SDK.
 
-The minimum required version is `2.1.0` for the Redis source.
+If Redis support is desired, then it optionally depends on the C++ server-side SDK's Redis Source. 
 
+| Dependency                     | Minimum Version                                                                                            | Notes                                      |
+|--------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| C++ Server-Side SDK            | [3.3.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.3.0)              | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.1.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.0) | Optional, if using Redis as a data source. |
+
+
+3rd Party Dependencies
+------------
+Depending on how the C++ server-side SDK was built, the Lua SDK may require additional runtime dependencies to work properly.
+
+
+| Dependency | If C++ SDK compiled with..   | Notes                                                                  |
+|------------|------------------------------|------------------------------------------------------------------------|
+| OpenSSL    | `LD_DYNAMIC_LINK_OPENSSL=ON` | If linking OpenSSL dynamically, it must be present on target system.   |
+| Boost      | `LD_DYNAMIC_LINK_BOOST=ON`   | If linking Boost dynamically, it must be present on the target system. |
+
+_Note: The CI process builds against the C++ Server-side SDK's Linux shared libraries, which were compiled with `LD_DYNAMIC_LINK_BOOST=ON` so
+Boost is fetched as part of the build process._
 
 
 Getting started
 -----------
 
 Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/server-side/lua#getting-started) for instructions on getting started with using the SDK.
+
+To compile the LuaRock modules:
+1. Install [LuaRocks](https://github.com/luarocks/luarocks/wiki/Download)
+2. Build the [C++ Server-side SDK](https://github.com/launchdarkly/cpp-sdks) from source using CMake, or obtain pre-built artifacts from the [releases page](https://github.com/launchdarkly/cpp-sdks/releases?q=%22launchdarkly-cpp-server%22)
+3. Run `luarocks make`:
+```bash
+# Base SDK
+luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
+LD_DIR=./path-to-installed-cpp-sdk
+
+# SDK with Redis
+luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
+LDREDIS_DIR=./path-to-installed-cpp-sdk
+```
+
+Please note that the Lua SDK uses the C++ server-side SDK's C bindings, so if you're using prebuilt artifacts
+then only a C99 compiler is necessary.
 
 Learn more
 -----------

--- a/launchdarkly-server-sdk-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-1.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk"
 
 rockspec_format = "3.0"
 
-supported_platforms = {"linux"}
+-- supported_platforms = {"linux"}
 
 version = "1.0-0"
 

--- a/launchdarkly-server-sdk-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-1.0-0.rockspec
@@ -18,15 +18,6 @@ external_dependencies = {
         header = "launchdarkly/server_side/bindings/c/sdk.h",
         library = "launchdarkly-cpp-server"
     },
-    platforms = {
-        linux = {
-            BOOST = {
-                -- The library depends on boost_json and boost_url, but we only need to test for the existence
-                -- of one of them since they are both part of the boost distribution.
-                library = "libboost_json-mt-x64.so.1.81.0"
-            }
-        }
-    }
 }
 
 test = {
@@ -39,9 +30,12 @@ build = {
    modules = {
       ["launchdarkly_server_sdk"] = {
           sources = { "launchdarkly-server-sdk.c" },
+          -- Uncomment to compile with debug messages, mainly to help debug parsing configuration/context
+          -- builders.
+          -- defines = {"DEBUG=1"},
           incdirs = {"$(LD_INCDIR)"},
           libdirs = {"$(LD_LIBDIR)"},
-          libraries = {"launchdarkly-cpp-server"}
+          libraries = {"launchdarkly-cpp-server"},
       }
    }
 }

--- a/launchdarkly-server-sdk-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-1.0-0.rockspec
@@ -2,8 +2,6 @@ package = "launchdarkly-server-sdk"
 
 rockspec_format = "3.0"
 
--- supported_platforms = {"linux"}
-
 version = "1.0-0"
 
 source = {

--- a/launchdarkly-server-sdk-redis-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-1.0-0.rockspec
@@ -19,13 +19,6 @@ external_dependencies = {
     LDREDIS = {
         header = "launchdarkly/server_side/bindings/c/integrations/redis/redis_source.h",
         library = "launchdarkly-cpp-server-redis-source"
-    },
-    platforms = {
-        linux = {
-            HIREDIS = {
-                library = "libhiredis.so.1.1.0"
-            }
-        }
     }
 }
 
@@ -41,7 +34,7 @@ build = {
           sources = { "launchdarkly-server-sdk-redis.c" },
           incdirs = {"$(LDREDIS_INCDIR)"},
           libdirs = {"$(LDREDIS_LIBDIR)"},
-          libraries = {"launchdarkly-cpp-server-redis-source"}
+          libraries = {"launchdarkly-cpp-server-redis-source", "hiredis"}
       }
    }
 }

--- a/launchdarkly-server-sdk-redis-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-1.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk-redis"
 
 rockspec_format = "3.0"
 
-supported_platforms = {"linux"}
+-- supported_platforms = {"linux"}
 
 version = "1.0-0"
 

--- a/launchdarkly-server-sdk-redis-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-1.0-0.rockspec
@@ -24,7 +24,7 @@ external_dependencies = {
 
 test = {
     type = "command",
-    script = "redis-test.lua"
+    script = "test-redis.lua"
 }
 
 build = {

--- a/launchdarkly-server-sdk-redis-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-1.0-0.rockspec
@@ -34,7 +34,7 @@ build = {
           sources = { "launchdarkly-server-sdk-redis.c" },
           incdirs = {"$(LDREDIS_INCDIR)"},
           libdirs = {"$(LDREDIS_LIBDIR)"},
-          libraries = {"launchdarkly-cpp-server-redis-source", "hiredis"}
+          libraries = {"launchdarkly-cpp-server-redis-source"}
       }
    }
 }

--- a/launchdarkly-server-sdk-redis-1.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-1.0-0.rockspec
@@ -2,10 +2,7 @@ package = "launchdarkly-server-sdk-redis"
 
 rockspec_format = "3.0"
 
--- supported_platforms = {"linux"}
-
 version = "1.0-0"
-
 
 source = {
    url = "git+https://github.com/launchdarkly/lua-server-sdk.git"

--- a/launchdarkly-server-sdk-redis.c
+++ b/launchdarkly-server-sdk-redis.c
@@ -43,7 +43,7 @@ LuaLDRedisMakeSource(lua_State *const l)
 
     *i = out_result.source;
 
-    luaL_getmetatable(l, "LaunchDarklyStoreInterface");
+    luaL_getmetatable(l, "LaunchDarklySourceInterface");
     lua_setmetatable(l, -2);
 
     return 1;
@@ -51,7 +51,7 @@ LuaLDRedisMakeSource(lua_State *const l)
 
 static const struct luaL_Reg launchdarkly_functions[] = {
     { "makeRedisSource", LuaLDRedisMakeSource },
-    { NULL,        NULL                }
+    { NULL, NULL}
 };
 
 #if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501

--- a/launchdarkly-server-sdk-redis.c
+++ b/launchdarkly-server-sdk-redis.c
@@ -15,11 +15,13 @@ Server-side SDK for LaunchDarkly Redis store.
 
 /***
 Create a Redis data source, which can be used instead
-of a LaunchDarkly Streaming or Polling data source.
+of a LaunchDarkly Streaming or Polling data source. This should be configured
+in the SDK's configuration table, under the dataSystem.lazyLoad.source property.
 @function makeRedisSource
-@tparam string uri Redis URI.
-@tparam string prefix Prefix to use when reading SDK data from Redis.
-@return A new Redis data source, suitable for configuration in the SDK's data system.
+@tparam string uri Redis URI. Example: 'redis://localhost:6379'.
+@tparam string prefix Prefix to use when reading SDK data from Redis. This is prefixed to all
+Redis keys used by this SDK. Example: 'my-environment'.
+@return A new Redis data source.
 */
 static int
 LuaLDRedisMakeSource(lua_State *const l)

--- a/launchdarkly-server-sdk-redis.c
+++ b/launchdarkly-server-sdk-redis.c
@@ -24,7 +24,7 @@ of a LaunchDarkly Streaming or Polling data source.
 static int
 LuaLDRedisMakeSource(lua_State *const l)
 {
-    if (lua_gettop(l) != 1) {
+    if (lua_gettop(l) != 2) {
         return luaL_error(l, "expecting exactly 2 arguments");
     }
 

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -411,17 +411,6 @@ LuaLDUserFree(lua_State *const l)
     return 0;
 }
 
-// makeConfig({
-//     dataSystem: {
-//         enabled: bool
-//         method: streaming
-//
-//
-//     }
-// })
-
-
-
 static LDServerConfig
 makeConfig(lua_State *const l, const int i)
 {
@@ -452,22 +441,6 @@ makeConfig(lua_State *const l, const int i)
     if (lua_isstring(l, -1)) {
         LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, luaL_checkstring(l, -1));
     }
-
-/*
-    local user = l.makeUser({
-        key = "alice",
-        dataSystem = {
-            enabled = true,
-            backgroundSync = {
-                source = "launchdarkly_streaming",
-                initialReconnectDelayMs = 1000
-            }
-lazyLoad = {
-        source = makeRedisSource("redis://localhost:6379", "prefix")
-}
-        }
-    })
-*/
 
 // TODO: stream, useLDD, and pollInterval, and featureStoreBackend all unified under new dataSystem key
     lua_getfield(l, i, "dataSystem");

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -1822,15 +1822,12 @@ LuaLDClientAllFlags(lua_State *const l)
 
     LDAllFlagsState state = LDServerSDK_AllFlagsState(*client, *context, LD_ALLFLAGSSTATE_DEFAULT);
 
-    char* serialized = LDAllFlagsState_SerializeJSON(state);
+	LDValue owned_map = LDAllFlagsState_Map(state);
 
-    /** TODO: Need to add a C binding to expose this as an LDValue, or have an iterator specific to it. **/
-    LDMemory_FreeString(serialized);
+	LuaPushJSON(l, owned_map);
 
+	LDValue_Free(owned_map);
     LDAllFlagsState_Free(state);
-
-    /* For now, return an empty table. */
-    lua_newtable(l);
 
     return 1;
 }

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -546,8 +546,8 @@ struct field_validator backgroundsync_fields[] = {
 DEFINE_CONFIG(backgroundsync_config, "dataSystem.backgroundSync", backgroundsync_fields);
 
 struct field_validator datasystem_fields[] = {
-    {"enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled}
-    //{"backgroundSync", LUA_TTABLE, parse_table, &backgroundsync_config},
+    {"enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled},
+    {"backgroundSync", LUA_TTABLE, parse_table, &backgroundsync_config},
    // {"lazyLoad", LUA_TTABLE, parse_table, &lazyload_config}
 };
 

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -557,25 +557,10 @@ struct field_validator top_level_fields[] = {
     {"events", LUA_TTABLE, parse_table, &event_config }
 };
 
-
 DEFINE_CONFIG(top_level_config, "config", top_level_fields);
 
-
-// todo: appinfo
-
-
-struct field_validator * find_field(const char *key, struct config* cfg) {
-    for (int i = 0; i < cfg->n; i++) {
-        if (strcmp(cfg->fields[i].key, key) == 0) {
-            return &cfg->fields[i];
-        }
-    }
-    return NULL;
-}
-
-#define DEBUG 1
-
-#define debug_print(foo) do { if (DEBUG) printf(foo); } while (0)
+// Finds a field by key in the given config, or returns NULL.
+struct field_validator * find_field(const char *key, struct config* cfg);
 
 void traverse_config(lua_State *const l, int i, LDServerConfigBuilder builder, struct config *cfg) {
     luaL_checktype(l, -1, LUA_TTABLE);
@@ -601,6 +586,15 @@ void traverse_config(lua_State *const l, int i, LDServerConfigBuilder builder, s
         lua_pop(l, 2);
     }
     lua_pop(l, 1);
+}
+
+struct field_validator * find_field(const char *key, struct config* cfg) {
+    for (int i = 0; i < cfg->n; i++) {
+        if (strcmp(cfg->fields[i].key, key) == 0) {
+            return &cfg->fields[i];
+        }
+    }
+    return NULL;
 }
 
 static LDServerConfig

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -546,9 +546,9 @@ struct field_validator backgroundsync_fields[] = {
 DEFINE_CONFIG(backgroundsync_config, "dataSystem.backgroundSync", backgroundsync_fields);
 
 struct field_validator datasystem_fields[] = {
-    {"enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled},
-    {"backgroundSync", LUA_TTABLE, parse_table, &backgroundsync_config},
-    {"lazyLoad", LUA_TTABLE, parse_table, &lazyload_config}
+    {"enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled}
+    //{"backgroundSync", LUA_TTABLE, parse_table, &backgroundsync_config},
+   // {"lazyLoad", LUA_TTABLE, parse_table, &lazyload_config}
 };
 
 DEFINE_CONFIG(datasystem_config, "dataSystem", datasystem_fields);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -1243,8 +1243,6 @@ LuaPushDetails(lua_State *const l, LDEvalDetail details,
     LDValue value)
 {
     lua_newtable(l);
-    /** TODO: C bindings for this? */
-
 
 	LDEvalReason out_reason;
 	if (LDEvalDetail_Reason(details, &out_reason)) {
@@ -1812,8 +1810,6 @@ LuaLDClientTrack(lua_State *const l)
 
     return 0;
 }
-
-// TODO: Document alias was removed, use multi context instead
 
 /***
 Check if a client has been fully initialized. This may be useful if the

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -641,7 +641,6 @@ makeConfig(lua_State *const l)
     const char* sdk_key = luaL_checkstring(l, 1);
     LDServerConfigBuilder builder = LDServerConfigBuilder_New(sdk_key);
 
-    luaL_checkstack(l, 64, "not enough stack space for config struct");
     // Recursively visit the heirarchical configs, modifying the builder
     // as we go along.
     traverse_config(l, builder, &top_level_config);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -39,8 +39,8 @@ LuaArrayToJSON(lua_State *const l, const int i);
 static void
 LuaPushJSON(lua_State *const l, LDValue j);
 
-static int globalLogEnabledCallback;
-static int globalLogWriteCallback;
+static int globalLogEnabledCallback = LUA_NOREF;
+static int globalLogWriteCallback = LUA_NOREF;
 
 static lua_State *globalLuaState;
 
@@ -457,6 +457,9 @@ and the values are tables containing context's information.
 @tparam[opt] [kind.privateAttributes] An array of attribute references, indicating which
 attributes should be marked private. Attribute references may be simple attribute names
 (like 'age'), or may use a JSON-pointer-like syntax (like '/contact/phone').
+@tparam[opt] [kind.name] A name for the context. This is useful for identifying the context
+in the LaunchDarkly dashboard.
+@tparam[opt] [kind.anonymous] A boolean indicating whether the context should be marked as anonymous.
 @treturn A fresh context.
 */
 static int

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -530,7 +530,7 @@ struct field_validator lazyload_fields[] = {
 DEFINE_CONFIG(lazyload_config, "dataSystem.lazyLoad", lazyload_fields);
 
 struct field_validator streaming_fields[] = {
-    {"initialReconnectDelayMilliseconds", LUA_TNUMBER, parse_number, NULL}
+    {"initialReconnectDelayMilliseconds", LUA_TNUMBER, parse_number, LDServerDataSourceStreamBuilder_InitialReconnectDelayMs}
 };
 
 DEFINE_CONFIG(streaming_config, "dataSystem.backgroundSync.streaming", streaming_fields);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -643,7 +643,7 @@ DEFINE_CONFIG(datasystem_config, "dataSystem", datasystem_fields);
 
 struct field_validator event_fields[] = {
     FIELD("enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_Events_Enabled),
-    FIELD("contextKeysCapacity", LUA_TNUMBER, NULL, NULL),
+    FIELD("contextKeysCapacity", LUA_TNUMBER, parse_unsigned, LDServerConfigBuilder_Events_ContextKeysCapacity),
     FIELD("capacity", LUA_TNUMBER, parse_unsigned, LDServerConfigBuilder_Events_Capacity),
     FIELD("flushIntervalMilliseconds", LUA_TNUMBER, parse_unsigned, LDServerConfigBuilder_Events_FlushIntervalMs),
     FIELD("allAttributesPrivate", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_Events_AllAttributesPrivate),

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -452,7 +452,7 @@ static void parse_bool(lua_State *const l, int i, LDServerConfigBuilder builder,
 // The setter must have the signature (LDServerConfigBuilder, int).
 static void parse_number(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
     const int value = lua_tointeger(l, i);
-    void (*setter)(LDServerConfigBuilder, int) = user_data;
+    void (*setter)(LDServerConfigBuilder, unsigned int) = user_data;
     setter(builder, value);
 }
 

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -471,7 +471,6 @@ static void parse_table(lua_State *const l, int i,  LDServerConfigBuilder builde
     // make it so.
     lua_pushvalue(l, i);
     traverse_config(l, builder, user_data);
-    lua_pop(l, 1);
 }
 
 
@@ -620,7 +619,7 @@ void traverse_config(lua_State *const l, LDServerConfigBuilder builder, struct c
         }
         lua_pop(l, 2);
     }
-   // lua_pop(l, 1);
+    lua_pop(l, 1);
 }
 
 struct field_validator * find_field(const char *key, struct config* cfg) {

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -641,6 +641,7 @@ makeConfig(lua_State *const l)
     const char* sdk_key = luaL_checkstring(l, 1);
     LDServerConfigBuilder builder = LDServerConfigBuilder_New(sdk_key);
 
+    luaL_checkstack(l, 64, "not enough stack space for config struct");
     // Recursively visit the heirarchical configs, modifying the builder
     // as we go along.
     traverse_config(l, builder, &top_level_config);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -1210,8 +1210,36 @@ LuaLDContextErrors(lua_State *const l)
 
     const char* error = LDContext_Errors(*context);
 
-    if (error) {
+    if (error && strlen(error) > 0) {
         lua_pushstring(l, error);
+    } else {
+        lua_pushnil(l);
+    }
+
+    return 1;
+}
+
+/**
+Returns the canonical key of the context.
+
+@class function
+@name canonicalKey
+@tparam context context An opaque context object from @{makeUser} or @{makeContext}
+@treturn Canonical key of the context, or nil if the context isn't valid.
+*/
+static int
+LuaLDContextCanonicalKey(lua_State *const l)
+{
+    if (lua_gettop(l) != 1) {
+        return luaL_error(l, "expecting exactly 1 argument");
+    }
+
+    LDContext *context = luaL_checkudata(l, 1, "LaunchDarklyContext");
+
+    const char* key = LDContext_CanonicalKey(*context);
+
+    if (key && strlen(key) > 0) {
+        lua_pushstring(l, key);
     } else {
         lua_pushnil(l);
     }
@@ -1721,6 +1749,7 @@ static const struct luaL_Reg launchdarkly_client_methods[] = {
 static const struct luaL_Reg launchdarkly_context_methods[] = {
     { "valid",  LuaLDContextValid  },
     { "errors", LuaLDContextErrors },
+    { "canonicalKey", LuaLDContextCanonicalKey },
     { "__gc", LuaLDContextFree },
     { NULL,   NULL          }
 };

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -455,8 +455,10 @@ static void parse_bool(lua_State *const l, int i, LDServerConfigBuilder builder,
 static void parse_number(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
     const int value = lua_tointeger(l, i);
     DEBUG_PRINT("number = %d\n", value);
-    void (*setter)(LDServerConfigBuilder, unsigned int) = user_data;
-    setter(builder, value);
+    if (user_data) {
+        void (*setter)(LDServerConfigBuilder, unsigned int) = user_data;
+        setter(builder, value);
+    }
 }
 
 // Forward declaration of the config used in traverse_config, to keep parse_table
@@ -528,7 +530,7 @@ struct field_validator lazyload_fields[] = {
 DEFINE_CONFIG(lazyload_config, "dataSystem.lazyLoad", lazyload_fields);
 
 struct field_validator streaming_fields[] = {
-    {"initialReconnectDelayMilliseconds", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled}
+    {"initialReconnectDelayMilliseconds", LUA_TNUMBER, parse_number, NULL}
 };
 
 DEFINE_CONFIG(streaming_config, "dataSystem.backgroundSync.streaming", streaming_fields);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -471,6 +471,7 @@ static void parse_table(lua_State *const l, int i,  LDServerConfigBuilder builde
     // make it so.
     lua_pushvalue(l, i);
     traverse_config(l, builder, user_data);
+    lua_pop(l, 1);
 }
 
 
@@ -619,7 +620,7 @@ void traverse_config(lua_State *const l, LDServerConfigBuilder builder, struct c
         }
         lua_pop(l, 2);
     }
-    lua_pop(l, 1);
+   // lua_pop(l, 1);
 }
 
 struct field_validator * find_field(const char *key, struct config* cfg) {

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -548,7 +548,7 @@ DEFINE_CONFIG(backgroundsync_config, "dataSystem.backgroundSync", backgroundsync
 struct field_validator datasystem_fields[] = {
     {"enabled", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled},
     {"backgroundSync", LUA_TTABLE, parse_table, &backgroundsync_config},
-   // {"lazyLoad", LUA_TTABLE, parse_table, &lazyload_config}
+    {"lazyLoad", LUA_TTABLE, parse_table, &lazyload_config}
 };
 
 DEFINE_CONFIG(datasystem_config, "dataSystem", datasystem_fields);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -471,22 +471,21 @@ static void parse_table(lua_State *const l, int i,  LDServerConfigBuilder builde
 static void parse_string_array(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
     void (*setter)(LDServerConfigBuilder, const char*) = user_data;
 
-    int n = lua_tablelen(l, -1);
+    int n = lua_tablelen(l, i);
 
-    for (int i = 1; i <= n; i++) {
-        lua_rawgeti(l, -1, i);
+    for (int j = 1; j <= n; j++) {
+        lua_rawgeti(l, i, j);
         if (lua_isstring(l, -1)) {
             setter(builder, lua_tostring(l, -1));
         }
         lua_pop(l, 1);
     }
-
 }
 
 // Special purpose parser for grabbing a store interface from a userdata.
 static void parse_lazyload_source(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
 // TODO: replace checkudata
-    LDServerLazyLoadSourcePtr *source = luaL_checkudata(l, i, "LaunchDarklyStoreInterface");
+    LDServerLazyLoadSourcePtr *source = lua_touserdata(l, i);
     LDServerLazyLoadBuilder lazy_load_builder = LDServerLazyLoadBuilder_New();
     LDServerLazyLoadBuilder_SourcePtr(lazy_load_builder, *source);
 

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -519,13 +519,11 @@ static void parse_string_array(lua_State *const l, int i, void* builder, void* s
     }
 }
 
-// Special purpose parser for grabbing a store interface from a userdata.
+// Special purpose parser for extracting a LaunchDarklySourceInterface from
+// the stack. Setter must have the signature (void*, void*).
 static void parse_lazyload_source(lua_State *const l, int i, void* builder, void* setter) {
-    // TODO: check that this implements the correct userdata.
-    LDServerLazyLoadSourcePtr *source = lua_touserdata(l, i);
-
+    LDServerLazyLoadSourcePtr *source = luaL_checkudata(l, i, "LaunchDarklySourceInterface");
     DEBUG_PRINT("source = %p\n", *source);
-
     void (*source_setter)(void*, void*) = setter;
 
     // Dereferencing source because lua_touserdata returns a pointer (to our pointer).
@@ -1470,7 +1468,7 @@ static const struct luaL_Reg launchdarkly_user_methods[] = {
     { NULL,   NULL          }
 };
 
-static const struct luaL_Reg launchdarkly_store_methods[] = {
+static const struct luaL_Reg launchdarkly_source_methods[] = {
     { NULL, NULL }
 };
 
@@ -1507,10 +1505,10 @@ luaopen_launchdarkly_server_sdk(lua_State *const l)
     lua_setfield(l, -2, "__index");
     ld_luaL_setfuncs(l, launchdarkly_user_methods, 0);
 
-    luaL_newmetatable(l, "LaunchDarklyStoreInterface");
+    luaL_newmetatable(l, "LaunchDarklySourceInterface");
     lua_pushvalue(l, -1);
     lua_setfield(l, -2, "__index");
-    ld_luaL_setfuncs(l, launchdarkly_store_methods, 0);
+    ld_luaL_setfuncs(l, launchdarkly_source_methods, 0);
 
     #if LUA_VERSION_NUM >= 502
         luaL_newlib(l, launchdarkly_functions);

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -435,15 +435,17 @@ struct field_validator {
 // Parses a string and then calls a setter function stored in user_data.
 // The setter must have the signature (LDServerConfigBuilder, const char*).
 static void parse_string(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
-    const char *const uri = lua_tostring(l, i);
+    const char *const value = lua_tostring(l, i);
+    DEBUG_PRINT("string = %s\n", value ? value : "NULL");
     void (*setter)(LDServerConfigBuilder, const char*) = user_data;
-    setter(builder, uri);
+    setter(builder, value);
 }
 
 // Parses a bool and then calls a setter function stored in user_data.
 // The setter must have the signature (LDServerConfigBuilder, bool).
 static void parse_bool(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
     const bool value = lua_toboolean(l, i);
+    DEBUG_PRINT("bool = %s\n", value ? "true" : "false");
     void (*setter)(LDServerConfigBuilder, bool) = user_data;
     setter(builder, value);
 }
@@ -452,6 +454,7 @@ static void parse_bool(lua_State *const l, int i, LDServerConfigBuilder builder,
 // The setter must have the signature (LDServerConfigBuilder, int).
 static void parse_number(lua_State *const l, int i, LDServerConfigBuilder builder, void* user_data) {
     const int value = lua_tointeger(l, i);
+    DEBUG_PRINT("number = %d\n", value);
     void (*setter)(LDServerConfigBuilder, unsigned int) = user_data;
     setter(builder, value);
 }
@@ -525,13 +528,13 @@ struct field_validator lazyload_fields[] = {
 DEFINE_CONFIG(lazyload_config, "dataSystem.lazyLoad", lazyload_fields);
 
 struct field_validator streaming_fields[] = {
-    {"initialReconnectDelayMilliseconds", LUA_TNUMBER, parse_number, LDServerDataSourceStreamBuilder_InitialReconnectDelayMs},
+    {"initialReconnectDelayMilliseconds", LUA_TBOOLEAN, parse_bool, LDServerConfigBuilder_DataSystem_Enabled}
 };
 
 DEFINE_CONFIG(streaming_config, "dataSystem.backgroundSync.streaming", streaming_fields);
 
 struct field_validator polling_fields[] = {
-    {"intervalSeconds", LUA_TNUMBER, parse_number, LDServerDataSourcePollBuilder_IntervalS},
+    {"intervalSeconds", LUA_TNUMBER, parse_number, LDServerDataSourcePollBuilder_IntervalS}
 };
 
 DEFINE_CONFIG(polling_config, "dataSystem.backgroundSync.polling", polling_fields);

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -23,7 +23,6 @@ function makeTestClient()
             },
         }
     })
-
     return c
 end
 

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -16,22 +16,19 @@ TestAll = {}
 
 function makeTestClient()
     local c = l.clientInit({
-        key     = "sdk-test",
-        offline = True
+        key = "sdk-test",
+        dataSystem = {
+            lazyLoad = {
+                source = r.makeRedisSource('redis://localhost:1234', 'test-prefix')
+            }
+        }
     }, 0)
 
     return c
 end
 
 local user = l.makeUser({
-    key = "alice",
-    dataSystem = {
-        enabled = true,
-        method = "streaming",
-        params = {
-            initialReconnectDelayMs = 1000
-        }
-    }
+    key = "alice"
 })
 
 function TestAll:tearDown()
@@ -39,20 +36,8 @@ function TestAll:tearDown()
 end
 
 function TestAll:testRedisBasic()
-    local c = l.clientInit({
-        key                 = "sdk-test",
-        dataSystem = {
-            backgroundSync = {
-                lazyLoad = {
-                    source = r.makeRedisSource("redis://localhost:1234", "test-prefix")
-                }
-            }
-        }
-    }, 0)
-
     local e = false
-
-    u.assertEquals(e, c:boolVariation(user, "test", e))
+    u.assertEquals(e, makeTestClient():boolVariation(user, "test", e))
 end
 
 local runner = u.LuaUnit.new()

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -16,7 +16,6 @@ TestAll = {}
 
 function makeTestClient()
     local c = l.clientInit("sdk-test", {
-        baseURI = "foo",
         dataSystem = {
             enabled = true,
             lazyLoad = {

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -1,4 +1,5 @@
 local u = require('luaunit')
+local l = require("launchdarkly_server_sdk")
 local r = require("launchdarkly_server_sdk_redis")
 
 function logWrite(level, line)
@@ -43,7 +44,7 @@ function TestAll:testRedisBasic()
         dataSystem = {
             backgroundSync = {
                 lazyLoad = {
-                    source = makeRedisSource("redis://localhost:1234", "test-prefix")
+                    source = r.makeRedisSource("redis://localhost:1234", "test-prefix")
                 }
             }
         }

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -15,14 +15,15 @@ l.registerLogger(logWrite, logEnabled)
 TestAll = {}
 
 function makeTestClient()
-    local c = l.clientInit({
-        key = "sdk-test",
+    local c = l.clientInit("sdk-test", {
+        baseURI = "foo",
         dataSystem = {
+            enabled = true,
             lazyLoad = {
                 source = r.makeRedisSource('redis://localhost:1234', 'test-prefix')
-            }
+            },
         }
-    }, 0)
+    })
 
     return c
 end

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -35,9 +35,21 @@ function TestAll:tearDown()
     collectgarbage("collect")
 end
 
-function TestAll:testRedisBasic()
+function TestAll:testVariationWithRedisSource()
     local e = false
     u.assertEquals(e, makeTestClient():boolVariation(user, "test", e))
+end
+
+function TestAll:testVariationDetailWithRedisSource()
+    local e = {
+        value  = true,
+        reason = {
+            kind      = "ERROR",
+            errorKind = "CLIENT_NOT_READY",
+            inExperiment = false
+        }
+    }
+    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
 end
 
 local runner = u.LuaUnit.new()

--- a/redis-test.lua
+++ b/redis-test.lua
@@ -19,6 +19,7 @@ function makeTestClient()
         dataSystem = {
             enabled = true,
             lazyLoad = {
+                cacheRefreshMilliseconds = 1000,
                 source = r.makeRedisSource('redis://localhost:1234', 'test-prefix')
             },
         }

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Convenience to compile both the normal SDK and Redis luarocks at once, using
+# the paths fetched by ./get-cpp-sdk-locally.sh.
+
 set -e
 luarocks make launchdarkly-server-sdk-1.0-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
 luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+luarocks make launchdarkly-server-sdk-1.0-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
+luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL

--- a/scripts/get-cpp-sdk-locally.sh
+++ b/scripts/get-cpp-sdk-locally.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# This is meant to be run when testing out changes locally without the help of CI.
-# In CI, the C++ SDK's prebuilt Linux artifacts are fetched.
+# This is meant to be run when testing out changes locally. In contrast, the remote CI
+# fetches prebuilt artifacts from github based on a release tag.
 #
 # Locally, it's more convenient to built the C++ SDK from source - to be able to switch branches,
 # change built options, etc.
 
 # Usage: ./scripts/build-cpp-server.sh <tag>
+# If no tag is supplied, it uses 'main'.
+#
+# The SDK headers/libs are installed in ./cpp-sdks/build/INSTALL.
 
 set -e
 

--- a/scripts/get-cpp-sdk-locally.sh
+++ b/scripts/get-cpp-sdk-locally.sh
@@ -13,15 +13,7 @@
 
 set -e
 
-branch="main"
-
-if [ -n "$1" ]
-then
-    branch="$1"
-fi
-
-
-git clone --depth 1 --branch "$branch" https://github.com/launchdarkly/cpp-sdks.git
+git clone --depth 1 --branch "${1:-main}" https://github.com/launchdarkly/cpp-sdks.git
 cd cpp-sdks
 mkdir build
 cd build

--- a/scripts/get-cpp-sdk-locally.sh
+++ b/scripts/get-cpp-sdk-locally.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This is meant to be run when testing out changes locally without the help of CI.
+# In CI, the C++ SDK's prebuilt Linux artifacts are fetched.
+#
+# Locally, it's more convenient to built the C++ SDK from source - to be able to switch branches,
+# change built options, etc.
+
 # Usage: ./scripts/build-cpp-server.sh <tag>
 
 set -e
@@ -16,7 +22,7 @@ git clone --depth 1 --branch "$branch" https://github.com/launchdarkly/cpp-sdks.
 cd cpp-sdks
 mkdir build
 cd build
-cmake -D LD_BUILD_SHARED_LIBS=ON \
+cmake -GNinja -D LD_BUILD_SHARED_LIBS=ON \
       -D BUILD_TESTING=OFF \
       -D LD_BUILD_EXAMPLES=OFF \
       -D LD_BUILD_REDIS_SUPPORT=ON \

--- a/test-redis.lua
+++ b/test-redis.lua
@@ -35,6 +35,10 @@ function TestAll:tearDown()
     collectgarbage("collect")
 end
 
+function TestAll:testInvalidRedisArguments()
+    u.assertErrorMsgContains('invalid URI', r.makeRedisSource, 'not a uri', 'test-prefix')
+end
+
 function TestAll:testVariationWithRedisSource()
     local e = false
     u.assertEquals(e, makeTestClient():boolVariation(user, "test", e))

--- a/test-redis.lua
+++ b/test-redis.lua
@@ -22,6 +22,9 @@ function makeTestClient()
                 cacheRefreshMilliseconds = 1000,
                 source = r.makeRedisSource('redis://localhost:1234', 'test-prefix')
             },
+        },
+        events = {
+            enabled = false
         }
     })
 end
@@ -55,6 +58,10 @@ function TestAll:testVariationDetailWithRedisSource()
         }
     }
     u.assertEquals(makeTestClient():boolVariationDetail(context, "test", true), e)
+end
+
+function TestAll:testAllFlags()
+    u.assertEquals(makeTestClient():allFlags(context), {})
 end
 
 local runner = u.LuaUnit.new()

--- a/test-redis.lua
+++ b/test-redis.lua
@@ -15,7 +15,7 @@ l.registerLogger(logWrite, logEnabled)
 TestAll = {}
 
 function makeTestClient()
-    local c = l.clientInit("sdk-test", {
+    return l.clientInit("sdk-test", 0, {
         dataSystem = {
             enabled = true,
             lazyLoad = {
@@ -24,7 +24,6 @@ function makeTestClient()
             },
         }
     })
-    return c
 end
 
 local user = l.makeUser({

--- a/test-redis.lua
+++ b/test-redis.lua
@@ -26,8 +26,10 @@ function makeTestClient()
     })
 end
 
-local user = l.makeUser({
-    key = "alice"
+local context = l.makeContext({
+    user = {
+        key = "alice"
+    }
 })
 
 function TestAll:tearDown()
@@ -40,7 +42,7 @@ end
 
 function TestAll:testVariationWithRedisSource()
     local e = false
-    u.assertEquals(e, makeTestClient():boolVariation(user, "test", e))
+    u.assertEquals(e, makeTestClient():boolVariation(context, "test", e))
 end
 
 function TestAll:testVariationDetailWithRedisSource()
@@ -52,7 +54,7 @@ function TestAll:testVariationDetailWithRedisSource()
             inExperiment = false
         }
     }
-    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
+    u.assertEquals(makeTestClient():boolVariationDetail(context, "test", true), e)
 end
 
 local runner = u.LuaUnit.new()

--- a/test-redis.lua
+++ b/test-redis.lua
@@ -2,16 +2,6 @@ local u = require('luaunit')
 local l = require("launchdarkly_server_sdk")
 local r = require("launchdarkly_server_sdk_redis")
 
-function logWrite(level, line)
-    print("[" .. level .. "]" .. " " .. line)
-end
-
-function logEnabled(level)
-    return level == "warn" or level == "error"
-end
-
-l.registerLogger(logWrite, logEnabled)
-
 TestAll = {}
 
 function makeTestClient()
@@ -25,6 +15,12 @@ function makeTestClient()
         },
         events = {
             enabled = false
+        },
+        logging = {
+            basic = {
+                tag = "LaunchDarklyLua",
+                level = "warn"
+            }
         }
     })
 end

--- a/test.lua
+++ b/test.lua
@@ -50,7 +50,7 @@ function TestAll:testSetAllConfigFields()
         },
         events = {
             capacity = 1000,
-            --contextKeysCapacity = 100, TODO: once c binding available
+            --contextKeysCapacity = 100, TODO: add once c binding available
             enabled = true,
             flushIntervalMilliseconds = 100,
             allAttributesPrivate = true

--- a/test.lua
+++ b/test.lua
@@ -45,7 +45,7 @@ function TestAll:testSetAllConfigFields()
             enabled = true,
             backgroundSync = {
                 polling = {
-                    intervalSeconds = 1000
+                    -- intervalSeconds = 1000
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -71,6 +71,7 @@ function TestAll:testUserContext()
         }
     })
     u.assertIsTrue(c:valid())
+    u.assertEquals(c:canonicalKey(), "bob")
 end
 
 
@@ -93,6 +94,7 @@ function TestAll:testMultiKindContext()
         }
     })
     u.assertIsTrue(c:valid())
+    u.assertEquals(c:canonicalKey(), "user:bob:vehicle:tractor")
 end
 
 function TestAll:testInvalidContextFormats()
@@ -117,8 +119,8 @@ function TestAll:testInvalidContexts()
     for _, context in ipairs(invalid_contexts) do
         u.assertIsFalse(context:valid())
         u.assertNotIsNil(context:errors())
+        u.assertIsNil(context:canonicalKey())
     end
-
 end
 
 function TestAll:testBoolVariation()

--- a/test.lua
+++ b/test.lua
@@ -44,8 +44,8 @@ function TestAll:testSetAllConfigFields()
         dataSystem = {
             enabled = true,
             backgroundSync = {
-                streaming = {
-                    --initialReconnectDelayMilliseconds = 1000
+                polling = {
+                    intervalSeconds = 1000
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -14,10 +14,9 @@ l.registerLogger(logWrite, logEnabled)
 TestAll = {}
 
 function makeTestClient()
-    local c = l.clientInit({
-        key     = "sdk-test",
-        offline = True
-    }, 0)
+    local c = l.clientInit("sdk-test", {
+        offline = true
+    })
 
     return c
 end
@@ -40,7 +39,7 @@ function TestAll:testBoolVariationDetail()
         value  = true,
         reason = {
             kind      = "ERROR",
-            errorKind = "CLIENT_NOT_READY",
+            errorKind = "FLAG_NOT_FOUND",
             inExperiment = false
         }
     }
@@ -57,7 +56,7 @@ function TestAll:testIntVariationDetail()
         value  = 5,
         reason = {
             kind      = "ERROR",
-            errorKind = "CLIENT_NOT_READY",
+            errorKind = "FLAG_NOT_FOUND",
             inExperiment = false
         }
     }
@@ -74,7 +73,7 @@ function TestAll:testDoubleVariationDetail()
         value  = 6.2,
         reason = {
             kind      = "ERROR",
-            errorKind = "CLIENT_NOT_READY",
+            errorKind = "FLAG_NOT_FOUND",
             inExperiment = false
         }
     }
@@ -91,7 +90,7 @@ function TestAll:testStringVariationDetail()
         value  = "f",
         reason = {
             kind      = "ERROR",
-            errorKind = "CLIENT_NOT_READY",
+            errorKind = "FLAG_NOT_FOUND",
             inExperiment = false
         }
     }
@@ -108,7 +107,7 @@ function TestAll:testJSONVariationDetail()
         value  = { a = "b" },
         reason = {
             kind      = "ERROR",
-            errorKind = "CLIENT_NOT_READY",
+            errorKind = "FLAG_NOT_FOUND",
             inExperiment = false
         }
     }

--- a/test.lua
+++ b/test.lua
@@ -1,6 +1,5 @@
 local u = require('luaunit')
 local l = require("launchdarkly_server_sdk")
--- local r = require("launchdarkly_server_sdk_redis")
 
 function logWrite(level, line)
     print("[" .. level .. "]" .. " " .. line)

--- a/test.lua
+++ b/test.lua
@@ -42,12 +42,12 @@ function TestAll:testSetAllConfigFields()
             eventsBaseURL = "baz"
         },
         dataSystem = {
-            enabled = true
-            --backgroundSync = {
+            enabled = true,
+            backgroundSync = {
             --    streaming = {
             --        initialReconnectDelayMilliseconds = 1000
             --    }
-            --}
+            }
         },
         --events = {
         --    capacity = 1000,

--- a/test.lua
+++ b/test.lua
@@ -35,12 +35,12 @@ function TestAll:testSetAllConfigFields()
         appInfo = {
             identifier = "MyApp",
             version = "1.0.0"
-        }
-        --serviceEndpoints = {
-        --    streamingBaseURL = "foo",
-        --    pollingBaseURL = "bar",
-        --    eventsBaseURL = "baz"
-        --},
+        },
+        serviceEndpoints = {
+            streamingBaseURL = "foo",
+            pollingBaseURL = "bar",
+            eventsBaseURL = "baz"
+        },
         --dataSystem = {
         --    backgroundSync = {
         --        streaming = {

--- a/test.lua
+++ b/test.lua
@@ -21,6 +21,12 @@ local user = l.makeUser({
     key = "alice"
 })
 
+local context = l.makeContext({
+    user = {
+        key = "alice"
+    }
+})
+
 function TestAll:tearDown()
     collectgarbage("collect")
 end
@@ -130,6 +136,7 @@ end
 function TestAll:testBoolVariation()
     local e = false
     u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)
+    u.assertEquals(makeTestClient():boolVariation(context, "test", e), e)
 end
 
 function TestAll:testBoolVariationDetail()
@@ -142,11 +149,13 @@ function TestAll:testBoolVariationDetail()
         }
     }
     u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
+    u.assertEquals(makeTestClient():boolVariationDetail(context, "test", true), e)
 end
 
 function TestAll:testIntVariation()
     local e = 3
     u.assertEquals(makeTestClient():intVariation(user, "test", e), e)
+    u.assertEquals(makeTestClient():intVariation(context, "test", e), e)
 end
 
 function TestAll:testIntVariationDetail()
@@ -159,11 +168,13 @@ function TestAll:testIntVariationDetail()
         }
     }
     u.assertEquals(makeTestClient():intVariationDetail(user, "test", 5), e)
+    u.assertEquals(makeTestClient():intVariationDetail(context, "test", 5), e)
 end
 
 function TestAll:testDoubleVariation()
     local e = 12.5
     u.assertEquals(makeTestClient():doubleVariation(user, "test", e), e)
+    u.assertEquals(makeTestClient():doubleVariation(context, "test", e), e)
 end
 
 function TestAll:testDoubleVariationDetail()
@@ -176,11 +187,13 @@ function TestAll:testDoubleVariationDetail()
         }
     }
     u.assertEquals( makeTestClient():doubleVariationDetail(user, "test", 6.2), e)
+    u.assertEquals( makeTestClient():doubleVariationDetail(context, "test", 6.2), e)
 end
 
 function TestAll:testStringVariation()
     local e = "a"
     u.assertEquals(makeTestClient():stringVariation(user, "test", e), e)
+    u.assertEquals(makeTestClient():stringVariation(context, "test", e), e)
 end
 
 function TestAll:testStringVariationDetail()
@@ -193,11 +206,13 @@ function TestAll:testStringVariationDetail()
         }
     }
     u.assertEquals(makeTestClient():stringVariationDetail(user, "test", "f"), e)
+    u.assertEquals(makeTestClient():stringVariationDetail(context, "test", "f"), e)
 end
 
 function TestAll:testJSONVariation()
     local e = { ["a"] = "b" }
     u.assertEquals(makeTestClient():jsonVariation(user, "test", e), e)
+    u.assertEquals(makeTestClient():jsonVariation(context, "test", e), e)
 end
 
 function TestAll:testJSONVariationDetail()
@@ -210,10 +225,12 @@ function TestAll:testJSONVariationDetail()
         }
     }
     u.assertEquals(makeTestClient():jsonVariationDetail(user, "test", { a = "b" }), e)
+    u.assertEquals(makeTestClient():jsonVariationDetail(context, "test", { a = "b" }), e)
 end
 
 function TestAll:testIdentify()
     makeTestClient():identify(user)
+    makeTestClient():identify(context)
 end
 
 function TestAll:testVersion()

--- a/test.lua
+++ b/test.lua
@@ -31,31 +31,31 @@ end
 
 function TestAll:testSetAllConfigFields()
     local c = l.clientInit("sdk-test", {
-        offline = true,
-        appInfo = {
-            identifier = "MyApp",
-            version = "1.0.0"
-        },
-        serviceEndpoints = {
-            streamingBaseURL = "foo",
-            pollingBaseURL = "bar",
-            eventsBaseURL = "baz"
-        },
-        dataSystem = {
-            backgroundSync = {
-                streaming = {
-                    initialReconnectDelayMilliseconds = 1000
-                }
-            }
-        },
-        events = {
-            capacity = 1000,
-            --contextKeysCapacity = 100, TODO: add once c binding available
-            enabled = true,
-            flushIntervalMilliseconds = 100,
-            allAttributesPrivate = true,
-            privateAttributes = {"/foo", "/bar"}
-        }
+        offline = true
+        --appInfo = {
+        --    identifier = "MyApp",
+        --    version = "1.0.0"
+        --},
+        --serviceEndpoints = {
+        --    streamingBaseURL = "foo",
+        --    pollingBaseURL = "bar",
+        --    eventsBaseURL = "baz"
+        --},
+        --dataSystem = {
+        --    backgroundSync = {
+        --        streaming = {
+        --            initialReconnectDelayMilliseconds = 1000
+        --        }
+        --    }
+        --},
+        --events = {
+        --    capacity = 1000,
+        --    --contextKeysCapacity = 100, TODO: add once c binding available
+        --    enabled = true,
+        --    flushIntervalMilliseconds = 100,
+        --    allAttributesPrivate = true,
+        --    privateAttributes = {"/foo", "/bar"}
+        --}
     })
 end
 --

--- a/test.lua
+++ b/test.lua
@@ -45,7 +45,7 @@ function TestAll:testSetAllConfigFields()
             enabled = true,
             backgroundSync = {
                 polling = {
-                    -- intervalSeconds = 1000
+                    intervalSeconds = 1000
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -56,7 +56,7 @@ function TestAll:testSetAllConfigFields()
     })
 end
 
-function TestAll:testImplicitUserContext()
+function TestAll:testUserContext()
     local c = l.makeContext({
         user = {
             key = "bob",
@@ -76,7 +76,7 @@ end
 
 
 function TestAll:testMultiKindContext()
-    l.makeContext({
+    local c = l.makeContext({
         user = {
             key = "bob",
             attributes = {
@@ -95,6 +95,19 @@ function TestAll:testMultiKindContext()
     })
     u.assertEquals(c.kinds, {"user", "vehicle"})
     u.assertEquals(c.canonicalKey, "user:bob:vehicle:tractor")
+end
+
+function TestAll:testInvalidContexts()
+    u.assertErrorMsgContains("must be context kinds", l.makeContext, {"foo", "bar"})
+    u.assertErrorMsgContains("must be tables", l.makeContext, {foo = 3})
+    u.assertErrorMsgContains("expecting exactly", l.makeContext, "foo", "bar")
+    u.assertErrorMsgContains("table expected", l.makeContext, 3)
+    u.assertErrorMsgContains("table expected", l.makeContext, "foo")
+    u.assertErrorMsgContains("device attributes must be a table", l.makeContext, {device = {key = "foo", attributes = 3}})
+    u.assertErrorMsgContains("device privateAttributes must be a table", l.makeContext, {device = {key = "foo", privateAttributes = 3}})
+    u.assertErrorMsgContains("must contain a key", l.makeContext, {device = {}})
+
+
 end
 
 function TestAll:testBoolVariation()

--- a/test.lua
+++ b/test.lua
@@ -23,14 +23,7 @@ function makeTestClient()
 end
 
 local user = l.makeUser({
-    key = "alice",
-    dataSystem = {
-        enabled = true,
-        method = "streaming",
-        params = {
-            initialReconnectDelayMs = 1000
-        }
-    }
+    key = "alice"
 })
 
 function TestAll:tearDown()
@@ -125,18 +118,6 @@ end
 function TestAll:testIdentify()
     makeTestClient():identify(user)
 end
-
---function TestAll:testRedisBasic()
---    local c = l.clientInit({
---        key                 = "sdk-test",
---        featureStoreBackend = r.makeStore({}),
---        offline             = true
---    }, 0)
---
---    local e = false
---
---    u.assertEquals(e, c:boolVariation(user, "test", e))
---end
 
 function TestAll:testVersion()
     local version = l.version()

--- a/test.lua
+++ b/test.lua
@@ -45,7 +45,7 @@ function TestAll:testSetAllConfigFields()
             enabled = true,
             backgroundSync = {
                 streaming = {
-                    initialReconnectDelayMilliseconds = 1000
+                    --initialReconnectDelayMilliseconds = 1000
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -45,7 +45,7 @@ function TestAll:testSetAllConfigFields()
             enabled = true,
             backgroundSync = {
                 streaming = {
-                    initialReconnectDelayMilliseconds = true
+                    initialReconnectDelayMilliseconds = 10
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -35,27 +35,27 @@ function TestAll:testSetAllConfigFields()
         appInfo = {
             identifier = "MyApp",
             version = "1.0.0"
-        },
-        serviceEndpoints = {
-            streamingBaseURL = "foo",
-            pollingBaseURL = "bar",
-            eventsBaseURL = "baz"
-        },
-        dataSystem = {
-            backgroundSync = {
-                streaming = {
-                    initialReconnectDelayMilliseconds = 1000
-                }
-            }
-        },
-        events = {
-            capacity = 1000,
-            --contextKeysCapacity = 100, TODO: add once c binding available
-            enabled = true,
-            flushIntervalMilliseconds = 100,
-            allAttributesPrivate = true,
-            privateAttributes = {"/foo", "/bar"}
         }
+        --serviceEndpoints = {
+        --    streamingBaseURL = "foo",
+        --    pollingBaseURL = "bar",
+        --    eventsBaseURL = "baz"
+        --},
+        --dataSystem = {
+        --    backgroundSync = {
+        --        streaming = {
+        --            initialReconnectDelayMilliseconds = 1000
+        --        }
+        --    }
+        --},
+        --events = {
+        --    capacity = 1000,
+        --    --contextKeysCapacity = 100, TODO: add once c binding available
+        --    enabled = true,
+        --    flushIntervalMilliseconds = 100,
+        --    allAttributesPrivate = true,
+        --    privateAttributes = {"/foo", "/bar"}
+        --}
     })
 end
 --

--- a/test.lua
+++ b/test.lua
@@ -257,6 +257,12 @@ function TestAll:testIdentify()
     makeTestClient():identify(context)
 end
 
+
+function TestAll:testAllFlags()
+    u.assertEquals(makeTestClient():allFlags(user), {})
+    u.assertEquals(makeTestClient():allFlags(context), {})
+end
+
 function TestAll:testVersion()
     local version = l.version()
     u.assertNotIsNil(version)

--- a/test.lua
+++ b/test.lua
@@ -56,6 +56,36 @@ function TestAll:testSetAllConfigFields()
     })
 end
 
+function TestAll:testImplicitUserContext()
+    local c = l.makeContext({
+        key = "foo"
+    })
+    u.assertEquals(c.kinds, {"user"})
+    u.assertEquals(c.canonicalKey, "foo")
+end
+
+function TestAll:testExplicitContextKind()
+    local c = l.makeContext({
+        kind = "device",
+        key = "foo"
+    })
+    u.assertEquals(c.kinds, {"device"})
+    u.assertEquals(c.canonicalKey, "foo")
+end
+
+function TestAll:testMultiKindContext()
+    local c = l.makeContext({
+        device = {
+            key = "foo"
+        },
+        user = {
+            key = "bar"
+        }
+    })
+    u.assertEquals(c.kinds, {"device", "user"})
+    u.assertEquals(c.canonicalKey, "device:foo:user:bar")
+end
+
 function TestAll:testBoolVariation()
     local e = false
     u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)

--- a/test.lua
+++ b/test.lua
@@ -45,7 +45,7 @@ function TestAll:testSetAllConfigFields()
             enabled = true,
             backgroundSync = {
                 streaming = {
-            --        initialReconnectDelayMilliseconds = 1000
+                    initialReconnectDelayMilliseconds = 1000
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -58,101 +58,101 @@ function TestAll:testSetAllConfigFields()
         }
     })
 end
-
-function TestAll:testBoolVariation()
-    local e = false
-    u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)
-end
-
-function TestAll:testBoolVariationDetail()
-    local e = {
-        value  = true,
-        reason = {
-            kind      = "ERROR",
-            errorKind = "FLAG_NOT_FOUND",
-            inExperiment = false
-        }
-    }
-    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
-end
-
-function TestAll:testIntVariation()
-    local e = 3
-    u.assertEquals(makeTestClient():intVariation(user, "test", e), e)
-end
-
-function TestAll:testIntVariationDetail()
-    local e = {
-        value  = 5,
-        reason = {
-            kind      = "ERROR",
-            errorKind = "FLAG_NOT_FOUND",
-            inExperiment = false
-        }
-    }
-    u.assertEquals(makeTestClient():intVariationDetail(user, "test", 5), e)
-end
-
-function TestAll:testDoubleVariation()
-    local e = 12.5
-    u.assertEquals(makeTestClient():doubleVariation(user, "test", e), e)
-end
-
-function TestAll:testDoubleVariationDetail()
-    local e = {
-        value  = 6.2,
-        reason = {
-            kind      = "ERROR",
-            errorKind = "FLAG_NOT_FOUND",
-            inExperiment = false
-        }
-    }
-    u.assertEquals( makeTestClient():doubleVariationDetail(user, "test", 6.2), e)
-end
-
-function TestAll:testStringVariation()
-    local e = "a"
-    u.assertEquals(makeTestClient():stringVariation(user, "test", e), e)
-end
-
-function TestAll:testStringVariationDetail()
-    local e = {
-        value  = "f",
-        reason = {
-            kind      = "ERROR",
-            errorKind = "FLAG_NOT_FOUND",
-            inExperiment = false
-        }
-    }
-    u.assertEquals(makeTestClient():stringVariationDetail(user, "test", "f"), e)
-end
-
-function TestAll:testJSONVariation()
-    local e = { ["a"] = "b" }
-    u.assertEquals(makeTestClient():jsonVariation(user, "test", e), e)
-end
-
-function TestAll:testJSONVariationDetail()
-    local e = {
-        value  = { a = "b" },
-        reason = {
-            kind      = "ERROR",
-            errorKind = "FLAG_NOT_FOUND",
-            inExperiment = false
-        }
-    }
-    u.assertEquals(makeTestClient():jsonVariationDetail(user, "test", { a = "b" }), e)
-end
-
-function TestAll:testIdentify()
-    makeTestClient():identify(user)
-end
-
-function TestAll:testVersion()
-    local version = l.version()
-    u.assertNotIsNil(version)
-    u.assertStrMatches(version, "(%d+)%.(%d+)%.(%d+)(.*)")
-end
+--
+--function TestAll:testBoolVariation()
+--    local e = false
+--    u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)
+--end
+--
+--function TestAll:testBoolVariationDetail()
+--    local e = {
+--        value  = true,
+--        reason = {
+--            kind      = "ERROR",
+--            errorKind = "FLAG_NOT_FOUND",
+--            inExperiment = false
+--        }
+--    }
+--    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
+--end
+--
+--function TestAll:testIntVariation()
+--    local e = 3
+--    u.assertEquals(makeTestClient():intVariation(user, "test", e), e)
+--end
+--
+--function TestAll:testIntVariationDetail()
+--    local e = {
+--        value  = 5,
+--        reason = {
+--            kind      = "ERROR",
+--            errorKind = "FLAG_NOT_FOUND",
+--            inExperiment = false
+--        }
+--    }
+--    u.assertEquals(makeTestClient():intVariationDetail(user, "test", 5), e)
+--end
+--
+--function TestAll:testDoubleVariation()
+--    local e = 12.5
+--    u.assertEquals(makeTestClient():doubleVariation(user, "test", e), e)
+--end
+--
+--function TestAll:testDoubleVariationDetail()
+--    local e = {
+--        value  = 6.2,
+--        reason = {
+--            kind      = "ERROR",
+--            errorKind = "FLAG_NOT_FOUND",
+--            inExperiment = false
+--        }
+--    }
+--    u.assertEquals( makeTestClient():doubleVariationDetail(user, "test", 6.2), e)
+--end
+--
+--function TestAll:testStringVariation()
+--    local e = "a"
+--    u.assertEquals(makeTestClient():stringVariation(user, "test", e), e)
+--end
+--
+--function TestAll:testStringVariationDetail()
+--    local e = {
+--        value  = "f",
+--        reason = {
+--            kind      = "ERROR",
+--            errorKind = "FLAG_NOT_FOUND",
+--            inExperiment = false
+--        }
+--    }
+--    u.assertEquals(makeTestClient():stringVariationDetail(user, "test", "f"), e)
+--end
+--
+--function TestAll:testJSONVariation()
+--    local e = { ["a"] = "b" }
+--    u.assertEquals(makeTestClient():jsonVariation(user, "test", e), e)
+--end
+--
+--function TestAll:testJSONVariationDetail()
+--    local e = {
+--        value  = { a = "b" },
+--        reason = {
+--            kind      = "ERROR",
+--            errorKind = "FLAG_NOT_FOUND",
+--            inExperiment = false
+--        }
+--    }
+--    u.assertEquals(makeTestClient():jsonVariationDetail(user, "test", { a = "b" }), e)
+--end
+--
+--function TestAll:testIdentify()
+--    makeTestClient():identify(user)
+--end
+--
+--function TestAll:testVersion()
+--    local version = l.version()
+--    u.assertNotIsNil(version)
+--    u.assertStrMatches(version, "(%d+)%.(%d+)%.(%d+)(.*)")
+--end
 
 local runner = u.LuaUnit.new()
 os.exit(runner:runSuite())

--- a/test.lua
+++ b/test.lua
@@ -31,6 +31,10 @@ function TestAll:tearDown()
     collectgarbage("collect")
 end
 
+function TestAll:testSetNoConfigFields()
+    u.assertNotIsNil(l.clientInit("sdk-test", 0, {}))
+end
+
 function TestAll:testSetAllConfigFields()
     local c = l.clientInit("sdk-test", 0, {
         offline = true,

--- a/test.lua
+++ b/test.lua
@@ -49,111 +49,111 @@ function TestAll:testSetAllConfigFields()
                 }
             }
         },
-        --events = {
-        --    capacity = 1000,
-        --    --contextKeysCapacity = 100, TODO: add once c binding available
-        --    enabled = true,
-        --    flushIntervalMilliseconds = 100,
-        --    allAttributesPrivate = true,
-        --    privateAttributes = {"/foo", "/bar"}
-        --}
+        events = {
+            capacity = 1000,
+            --contextKeysCapacity = 100, TODO: add once c binding available
+            enabled = true,
+            flushIntervalMilliseconds = 100,
+            allAttributesPrivate = true,
+            privateAttributes = {"/foo", "/bar"}
+        }
     })
 end
---
---function TestAll:testBoolVariation()
---    local e = false
---    u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)
---end
---
---function TestAll:testBoolVariationDetail()
---    local e = {
---        value  = true,
---        reason = {
---            kind      = "ERROR",
---            errorKind = "FLAG_NOT_FOUND",
---            inExperiment = false
---        }
---    }
---    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
---end
---
---function TestAll:testIntVariation()
---    local e = 3
---    u.assertEquals(makeTestClient():intVariation(user, "test", e), e)
---end
---
---function TestAll:testIntVariationDetail()
---    local e = {
---        value  = 5,
---        reason = {
---            kind      = "ERROR",
---            errorKind = "FLAG_NOT_FOUND",
---            inExperiment = false
---        }
---    }
---    u.assertEquals(makeTestClient():intVariationDetail(user, "test", 5), e)
---end
---
---function TestAll:testDoubleVariation()
---    local e = 12.5
---    u.assertEquals(makeTestClient():doubleVariation(user, "test", e), e)
---end
---
---function TestAll:testDoubleVariationDetail()
---    local e = {
---        value  = 6.2,
---        reason = {
---            kind      = "ERROR",
---            errorKind = "FLAG_NOT_FOUND",
---            inExperiment = false
---        }
---    }
---    u.assertEquals( makeTestClient():doubleVariationDetail(user, "test", 6.2), e)
---end
---
---function TestAll:testStringVariation()
---    local e = "a"
---    u.assertEquals(makeTestClient():stringVariation(user, "test", e), e)
---end
---
---function TestAll:testStringVariationDetail()
---    local e = {
---        value  = "f",
---        reason = {
---            kind      = "ERROR",
---            errorKind = "FLAG_NOT_FOUND",
---            inExperiment = false
---        }
---    }
---    u.assertEquals(makeTestClient():stringVariationDetail(user, "test", "f"), e)
---end
---
---function TestAll:testJSONVariation()
---    local e = { ["a"] = "b" }
---    u.assertEquals(makeTestClient():jsonVariation(user, "test", e), e)
---end
---
---function TestAll:testJSONVariationDetail()
---    local e = {
---        value  = { a = "b" },
---        reason = {
---            kind      = "ERROR",
---            errorKind = "FLAG_NOT_FOUND",
---            inExperiment = false
---        }
---    }
---    u.assertEquals(makeTestClient():jsonVariationDetail(user, "test", { a = "b" }), e)
---end
---
---function TestAll:testIdentify()
---    makeTestClient():identify(user)
---end
---
---function TestAll:testVersion()
---    local version = l.version()
---    u.assertNotIsNil(version)
---    u.assertStrMatches(version, "(%d+)%.(%d+)%.(%d+)(.*)")
---end
+
+function TestAll:testBoolVariation()
+    local e = false
+    u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)
+end
+
+function TestAll:testBoolVariationDetail()
+    local e = {
+        value  = true,
+        reason = {
+            kind      = "ERROR",
+            errorKind = "FLAG_NOT_FOUND",
+            inExperiment = false
+        }
+    }
+    u.assertEquals(makeTestClient():boolVariationDetail(user, "test", true), e)
+end
+
+function TestAll:testIntVariation()
+    local e = 3
+    u.assertEquals(makeTestClient():intVariation(user, "test", e), e)
+end
+
+function TestAll:testIntVariationDetail()
+    local e = {
+        value  = 5,
+        reason = {
+            kind      = "ERROR",
+            errorKind = "FLAG_NOT_FOUND",
+            inExperiment = false
+        }
+    }
+    u.assertEquals(makeTestClient():intVariationDetail(user, "test", 5), e)
+end
+
+function TestAll:testDoubleVariation()
+    local e = 12.5
+    u.assertEquals(makeTestClient():doubleVariation(user, "test", e), e)
+end
+
+function TestAll:testDoubleVariationDetail()
+    local e = {
+        value  = 6.2,
+        reason = {
+            kind      = "ERROR",
+            errorKind = "FLAG_NOT_FOUND",
+            inExperiment = false
+        }
+    }
+    u.assertEquals( makeTestClient():doubleVariationDetail(user, "test", 6.2), e)
+end
+
+function TestAll:testStringVariation()
+    local e = "a"
+    u.assertEquals(makeTestClient():stringVariation(user, "test", e), e)
+end
+
+function TestAll:testStringVariationDetail()
+    local e = {
+        value  = "f",
+        reason = {
+            kind      = "ERROR",
+            errorKind = "FLAG_NOT_FOUND",
+            inExperiment = false
+        }
+    }
+    u.assertEquals(makeTestClient():stringVariationDetail(user, "test", "f"), e)
+end
+
+function TestAll:testJSONVariation()
+    local e = { ["a"] = "b" }
+    u.assertEquals(makeTestClient():jsonVariation(user, "test", e), e)
+end
+
+function TestAll:testJSONVariationDetail()
+    local e = {
+        value  = { a = "b" },
+        reason = {
+            kind      = "ERROR",
+            errorKind = "FLAG_NOT_FOUND",
+            inExperiment = false
+        }
+    }
+    u.assertEquals(makeTestClient():jsonVariationDetail(user, "test", { a = "b" }), e)
+end
+
+function TestAll:testIdentify()
+    makeTestClient():identify(user)
+end
+
+function TestAll:testVersion()
+    local version = l.version()
+    u.assertNotIsNil(version)
+    u.assertStrMatches(version, "(%d+)%.(%d+)%.(%d+)(.*)")
+end
 
 local runner = u.LuaUnit.new()
 os.exit(runner:runSuite())

--- a/test.lua
+++ b/test.lua
@@ -14,11 +14,7 @@ l.registerLogger(logWrite, logEnabled)
 TestAll = {}
 
 function makeTestClient()
-    local c = l.clientInit("sdk-test", {
-        offline = true
-    })
-
-    return c
+    return l.clientInit("sdk-test", 0, { offline = true })
 end
 
 local user = l.makeUser({
@@ -30,7 +26,7 @@ function TestAll:tearDown()
 end
 
 function TestAll:testSetAllConfigFields()
-    local c = l.clientInit("sdk-test", {
+    local c = l.clientInit("sdk-test", 0, {
         offline = true,
         appInfo = {
             identifier = "MyApp",

--- a/test.lua
+++ b/test.lua
@@ -58,32 +58,43 @@ end
 
 function TestAll:testImplicitUserContext()
     local c = l.makeContext({
-        key = "foo"
-    })
-    u.assertEquals(c.kinds, {"user"})
-    u.assertEquals(c.canonicalKey, "foo")
-end
-
-function TestAll:testExplicitContextKind()
-    local c = l.makeContext({
-        kind = "device",
-        key = "foo"
-    })
-    u.assertEquals(c.kinds, {"device"})
-    u.assertEquals(c.canonicalKey, "foo")
-end
-
-function TestAll:testMultiKindContext()
-    local c = l.makeContext({
-        device = {
-            key = "foo"
-        },
         user = {
-            key = "bar"
+            key = "bob",
+            attributes = {
+                helmet = {
+                    type = "construction"
+                }
+            },
+            privateAttributes = {
+              "/helmet/type"
+            }
         }
     })
-    u.assertEquals(c.kinds, {"device", "user"})
-    u.assertEquals(c.canonicalKey, "device:foo:user:bar")
+    u.assertEquals(c.kinds, {"user"})
+    u.assertEquals(c.canonicalKey, "bob")
+end
+
+
+function TestAll:testMultiKindContext()
+    l.makeContext({
+        user = {
+            key = "bob",
+            attributes = {
+                age = 42
+            },
+            privateAttributes = {
+                "/age"
+            }
+        },
+        vehicle = {
+            key = "tractor",
+            attributes = {
+                horsepower = 2000
+            }
+        }
+    })
+    u.assertEquals(c.kinds, {"user", "vehicle"})
+    u.assertEquals(c.canonicalKey, "user:bob:vehicle:tractor")
 end
 
 function TestAll:testBoolVariation()

--- a/test.lua
+++ b/test.lua
@@ -44,9 +44,9 @@ function TestAll:testSetAllConfigFields()
         dataSystem = {
             enabled = true,
             backgroundSync = {
-            --    streaming = {
+                streaming = {
             --        initialReconnectDelayMilliseconds = 1000
-            --    }
+                }
             }
         },
         --events = {

--- a/test.lua
+++ b/test.lua
@@ -41,13 +41,14 @@ function TestAll:testSetAllConfigFields()
             pollingBaseURL = "bar",
             eventsBaseURL = "baz"
         },
-        --dataSystem = {
-        --    backgroundSync = {
-        --        streaming = {
-        --            initialReconnectDelayMilliseconds = 1000
-        --        }
-        --    }
-        --},
+        dataSystem = {
+            enabled = true
+            --backgroundSync = {
+            --    streaming = {
+            --        initialReconnectDelayMilliseconds = 1000
+            --    }
+            --}
+        },
         --events = {
         --    capacity = 1000,
         --    --contextKeysCapacity = 100, TODO: add once c binding available

--- a/test.lua
+++ b/test.lua
@@ -44,8 +44,8 @@ function TestAll:testSetAllConfigFields()
         dataSystem = {
             enabled = true,
             backgroundSync = {
-                polling = {
-                    intervalSeconds = 1000
+                streaming = {
+                    initialReconnectDelayMilliseconds = true
                 }
             }
         },

--- a/test.lua
+++ b/test.lua
@@ -62,6 +62,10 @@ function TestAll:testSetAllConfigFields()
             flushIntervalMilliseconds = 100,
             allAttributesPrivate = true,
             privateAttributes = {"/foo", "/bar"}
+        },
+        logging = {
+            level = "debug",
+            tag = "LaunchDarklyLuaTest"
         }
     })
 end

--- a/test.lua
+++ b/test.lua
@@ -72,6 +72,7 @@ function TestAll:testUserContext()
     })
     u.assertIsTrue(c:valid())
     u.assertEquals(c:canonicalKey(), "bob")
+    u.assertItemsEquals(c:privateAttributes("user"), {"/helmet/type"})
 end
 
 
@@ -95,6 +96,9 @@ function TestAll:testMultiKindContext()
     })
     u.assertIsTrue(c:valid())
     u.assertEquals(c:canonicalKey(), "user:bob:vehicle:tractor")
+    u.assertItemsEquals(c:privateAttributes("user"), {"/age"})
+    u.assertItemsEquals(c:privateAttributes("vehicle"), {})
+    u.assertIsNil(c:privateAttributes("foo"))
 end
 
 function TestAll:testInvalidContextFormats()

--- a/test.lua
+++ b/test.lua
@@ -47,7 +47,7 @@ function TestAll:testSetAllConfigFields()
         },
         events = {
             capacity = 1000,
-            --contextKeysCapacity = 100, TODO: add once c binding available
+            contextKeysCapacity = 100,
             enabled = true,
             flushIntervalMilliseconds = 100,
             allAttributesPrivate = true,

--- a/test.lua
+++ b/test.lua
@@ -70,8 +70,7 @@ function TestAll:testUserContext()
             }
         }
     })
-    u.assertEquals(c.kinds, {"user"})
-    u.assertEquals(c.canonicalKey, "bob")
+    u.assertIsTrue(c:valid())
 end
 
 
@@ -93,20 +92,32 @@ function TestAll:testMultiKindContext()
             }
         }
     })
-    u.assertEquals(c.kinds, {"user", "vehicle"})
-    u.assertEquals(c.canonicalKey, "user:bob:vehicle:tractor")
+    u.assertIsTrue(c:valid())
 end
 
-function TestAll:testInvalidContexts()
+function TestAll:testInvalidContextFormats()
     u.assertErrorMsgContains("must be context kinds", l.makeContext, {"foo", "bar"})
     u.assertErrorMsgContains("must be tables", l.makeContext, {foo = 3})
     u.assertErrorMsgContains("expecting exactly", l.makeContext, "foo", "bar")
     u.assertErrorMsgContains("table expected", l.makeContext, 3)
     u.assertErrorMsgContains("table expected", l.makeContext, "foo")
-    u.assertErrorMsgContains("device attributes must be a table", l.makeContext, {device = {key = "foo", attributes = 3}})
-    u.assertErrorMsgContains("device privateAttributes must be a table", l.makeContext, {device = {key = "foo", privateAttributes = 3}})
-    u.assertErrorMsgContains("must contain a key", l.makeContext, {device = {}})
+    u.assertErrorMsgContains("device: attributes must be a table", l.makeContext, {device = {key = "foo", attributes = 3}})
+    u.assertErrorMsgContains("device: privateAttributes must be a table", l.makeContext, {device = {key = "foo", privateAttributes = 3}})
+    u.assertErrorMsgContains("device: must contain key", l.makeContext, {device = {}})
+end
 
+function TestAll:testInvalidContexts()
+    local empty_key = l.makeContext({user = {key = ""}})
+    local no_kinds = l.makeContext({})
+    local invalid_kind_name_multi = l.makeContext({multi = {key = "foo"}})
+    local invalid_kind_name_kind = l.makeContext({kind = {key = "foo"}})
+    local invalid_kind_chars = l.makeContext({['invalid chars !'] = {key = "foo"}})
+
+    local invalid_contexts = {empty_key, no_kinds, invalid_kind_name_multi, invalid_kind_name_kind, invalid_kind_chars}
+    for _, context in ipairs(invalid_contexts) do
+        u.assertIsFalse(context:valid())
+        u.assertNotIsNil(context:errors())
+    end
 
 end
 

--- a/test.lua
+++ b/test.lua
@@ -53,7 +53,8 @@ function TestAll:testSetAllConfigFields()
             --contextKeysCapacity = 100, TODO: add once c binding available
             enabled = true,
             flushIntervalMilliseconds = 100,
-            allAttributesPrivate = true
+            allAttributesPrivate = true,
+            privateAttributes = {"/foo", "/bar"}
         }
     })
 end

--- a/test.lua
+++ b/test.lua
@@ -35,27 +35,27 @@ function TestAll:testSetAllConfigFields()
         appInfo = {
             identifier = "MyApp",
             version = "1.0.0"
+        },
+        serviceEndpoints = {
+            streamingBaseURL = "foo",
+            pollingBaseURL = "bar",
+            eventsBaseURL = "baz"
+        },
+        dataSystem = {
+            backgroundSync = {
+                streaming = {
+                    initialReconnectDelayMilliseconds = 1000
+                }
+            }
+        },
+        events = {
+            capacity = 1000,
+            --contextKeysCapacity = 100, TODO: add once c binding available
+            enabled = true,
+            flushIntervalMilliseconds = 100,
+            allAttributesPrivate = true,
+            privateAttributes = {"/foo", "/bar"}
         }
-        --serviceEndpoints = {
-        --    streamingBaseURL = "foo",
-        --    pollingBaseURL = "bar",
-        --    eventsBaseURL = "baz"
-        --},
-        --dataSystem = {
-        --    backgroundSync = {
-        --        streaming = {
-        --            initialReconnectDelayMilliseconds = 1000
-        --        }
-        --    }
-        --},
-        --events = {
-        --    capacity = 1000,
-        --    --contextKeysCapacity = 100, TODO: add once c binding available
-        --    enabled = true,
-        --    flushIntervalMilliseconds = 100,
-        --    allAttributesPrivate = true,
-        --    privateAttributes = {"/foo", "/bar"}
-        --}
     })
 end
 --

--- a/test.lua
+++ b/test.lua
@@ -29,6 +29,35 @@ function TestAll:tearDown()
     collectgarbage("collect")
 end
 
+function TestAll:testSetAllConfigFields()
+    local c = l.clientInit("sdk-test", {
+        offline = true,
+        appInfo = {
+            identifier = "MyApp",
+            version = "1.0.0"
+        },
+        serviceEndpoints = {
+            streamingBaseURL = "foo",
+            pollingBaseURL = "bar",
+            eventsBaseURL = "baz"
+        },
+        dataSystem = {
+            backgroundSync = {
+                streaming = {
+                    initialReconnectDelayMilliseconds = 1000
+                }
+            }
+        },
+        events = {
+            capacity = 1000,
+            --contextKeysCapacity = 100, TODO: once c binding available
+            enabled = true,
+            flushIntervalMilliseconds = 100,
+            allAttributesPrivate = true
+        }
+    })
+end
+
 function TestAll:testBoolVariation()
     local e = false
     u.assertEquals(makeTestClient():boolVariation(user, "test", e), e)

--- a/test.lua
+++ b/test.lua
@@ -31,11 +31,11 @@ end
 
 function TestAll:testSetAllConfigFields()
     local c = l.clientInit("sdk-test", {
-        offline = true
-        --appInfo = {
-        --    identifier = "MyApp",
-        --    version = "1.0.0"
-        --},
+        offline = true,
+        appInfo = {
+            identifier = "MyApp",
+            version = "1.0.0"
+        }
         --serviceEndpoints = {
         --    streamingBaseURL = "foo",
         --    pollingBaseURL = "bar",


### PR DESCRIPTION
This PR updates the Lua SDK to build against the C++ Server-side SDK with Redis v3.x via its provided C bindings. 

It will be the first `v2` release of this SDK.

The shape of the SDK mostly remains the same, with the major changes being:
- Users are replaced with contexts (`makeUser` is a wrapper, added`makeContext`)
- Configuration overhaul (nested configurations, type checking, data system)
- Removed obsolete config options and methods (like `alias`)
- Removed global logger config
