### PR TITLE
ci: add latest lua version to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: ./.github/actions/ci
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          lua-version: "5.3"
 
       - name: Build documentation
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
Forgot to add the `lua-version` to our release-please workflow, so that failed when I merged a release PR. Luckily we don't actually release any packages, so the only thing that we've missed was updating docs.