### PR TITLE
ci: gracefully handle already up-to-date rockspec version

### DIFF
--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -59,6 +59,11 @@ for file in "$input_rockspec"-*.rockspec; do
     echo "  package version: $semver"
     echo "  rockspec revision: $rockspec_revision"
 
+    # If the found version is what we're requesting, then we're done.
+    if [[ "$semver" == "$input_version" ]]; then
+        echo "$file is already at version $input_version"
+        exit 0
+    fi
 
     new_file_name="$input_rockspec-$input_version-$rockspec_revision.rockspec"
     git mv "$file" "$new_file_name"


### PR DESCRIPTION
When testing the `update versions` action, I found that it fails when existing rockspec matches the existing version. 

This updates the script to gracefully quit instead.