### PR TITLE
ci: release-please updates rockspec version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,7 @@
 name: Run Release Please
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -17,9 +18,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{ secrets.GITHUB_TOKEN }}
-          default-branch: main
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}
@@ -30,7 +29,7 @@ jobs:
         shell: bash
         run: |
           echo "semver=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}" >> $GITHUB_OUTPUT
-          echo "branch=${{ fromJSON(steps.release.outputs.prs).headBranchName }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ fromJSON(steps.release.outputs.pr).headBranchName }}" >> $GITHUB_OUTPUT
 
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions
@@ -49,16 +48,16 @@ jobs:
           version: ${{ steps.release-metadata.outputs.semver }}
 
       - name: Build and Test
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/ci
         with:
           lua-version: "5.3"
 
       - name: Build documentation
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/build-docs
 
       - uses: ./.github/actions/publish-docs
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.release_created }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Determine semantic version and PR branch from release-please output
         if: ${{ steps.release.outputs.prs_created == 'true' }}
-        id: determine-version-and-branch
+        id: release-metadata
         shell: bash
         run: |
           echo "semver=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}" >> $GITHUB_OUTPUT
@@ -34,19 +34,19 @@ jobs:
 
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.determine-version.outcome == 'success' }}
+        if: ${{ steps.release-metadata.outcome == 'success' }}
         with:
           package: launchdarkly-server-sdk
-          branch: ${{ steps.determine-version-and-branch.outputs.branch }}
-          version: ${{ steps.determine-version-and-branch.outputs.semver }}
+          branch: ${{ steps.release-metadata.outputs.branch }}
+          version: ${{ steps.release-metadata.outputs.semver }}
 
       - name: Update launchdarkly-server-sdk-redis rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.determine-version.outcome == 'success' }}
+        if: ${{ steps.release-metadata.outcome == 'success' }}
         with:
           package: launchdarkly-server-sdk-redis
-          branch: ${{ steps.determine-version-and-branch.outputs.branch }}
-          version: ${{ steps.determine-version.outputs.semver }}
+          branch: ${{ steps.release-metadata.outputs.branch }}
+          version: ${{ steps.release-metadata.outputs.semver }}
 
       - name: Build and Test
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           command: manifest
@@ -23,8 +23,30 @@ jobs:
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Determine semantic version and PR branch from release-please output
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        id: determine-version-and-branch
+        shell: bash
+        run: |
+          echo "semver=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ fromJSON(steps.release.outputs.prs).headBranchName }}" >> $GITHUB_OUTPUT
+
+      - name: Update launchdarkly-server-sdk rockspec
+        uses: ./.github/actions/update-versions
+        if: ${{ steps.determine-version.outcome == 'success' }}
         with:
-          fetch-depth: 0 # If you only need the current version keep this.
+          package: launchdarkly-server-sdk
+          branch: ${{ steps.determine-version-and-branch.outputs.branch }}
+          version: ${{ steps.determine-version-and-branch.outputs.semver }}
+
+      - name: Update launchdarkly-server-sdk-redis rockspec
+        uses: ./.github/actions/update-versions
+        if: ${{ steps.determine-version.outcome == 'success' }}
+        with:
+          package: launchdarkly-server-sdk-redis
+          branch: ${{ steps.determine-version-and-branch.outputs.branch }}
+          version: ${{ steps.determine-version.outputs.semver }}
 
       - name: Build and Test
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
This adds a new step after release-please runs: updating the `.rockspec` file names / versions and README example. It targets the release PR.

This requires updating to `release-please@v4`, which meant some changes. To facilitate testing these, I've added the `workflow_dispatch` trigger to the workflow.