### PR TITLE
docs: fix clientInit documentation

### DIFF
--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -1084,9 +1084,9 @@ you must set all of them. You probably don't need to set this unless instructed 
 LaunchDarkly.
 @tparam[opt] string config.serviceEndpoints.streamingBaseURL Set the streaming URL
 for connecting to LaunchDarkly.
-@tparam[opt] string config.serviceEndpoints.eventsURL Set the events URL for
+@tparam[opt] string config.serviceEndpoints.eventsBaseURL Set the events URL for
 connecting to LaunchDarkly.
-@tparam[opt] string config.serviceEndpoints.pollingURL Set the polling URL for
+@tparam[opt] string config.serviceEndpoints.pollingBaseURL Set the polling URL for
 connecting to LaunchDarkly.
 @tparam[opt] table config.events Options related to event generation and
 delivery.


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**


**Describe the solution you've provided**

endpoint_fields are declared with the following fields: `pollingBaseURL`, `streamingBaseURL` and `eventsBaseURL`

```
struct field_validator endpoint_fields[] = {
   FIELD("pollingBaseURL", LUA_TSTRING, parse_string, LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL),
   FIELD("streamingBaseURL", LUA_TSTRING, parse_string, LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL),
   FIELD("eventsBaseURL", LUA_TSTRING, parse_string, LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL)
};
```

The provided documentation doesn't match:

![image](https://github.com/launchdarkly/lua-server-sdk/assets/1489765/b13d1be7-3b6d-4ad1-9148-e03c8ffeabf1)

**Describe alternatives you've considered**

Fix function docs at: 

```
@tparam[opt] string config.serviceEndpoints.streamingBaseURL Set the streaming URL
for connecting to LaunchDarkly.
@tparam[opt] string config.serviceEndpoints.eventsURL Set the events URL for
connecting to LaunchDarkly.
@tparam[opt] string config.serviceEndpoints.pollingURL Set the polling URL for
connecting to LaunchDarkly.
```

**Additional context**

I found it while trying to put it running locally. And it throw imedially and error saying that the property doesn't exist.
