### PR TITLE
fix: add hello-lua-server example

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -48,19 +48,15 @@ runs:
 
     - name: Build Lua Server-side SDK
       shell: bash
-      # {x-release-please-start-version}
       run:  |
         luarocks make ${{ steps.rockspec-pkg-name.outputs.server }} \
         LD_DIR=./cpp-sdk/build-dynamic/release
-      # {x-release-please-end}
 
     - name: Build Lua Server-side SDK with Redis
       shell: bash
-      # {x-release-please-start-version}
       run: |
         luarocks make ${{ steps.rockspec-pkg-name.outputs.server_redis }} \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release
-      # {x-release-please-end}
 
     - name: Run Lua Server-side SDK Tests
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -48,15 +48,19 @@ runs:
 
     - name: Build Lua Server-side SDK
       shell: bash
+      # {x-release-please-start-version}
       run:  |
         luarocks make ${{ steps.rockspec-pkg-name.outputs.server }} \
         LD_DIR=./cpp-sdk/build-dynamic/release
+      # {x-release-please-end}
 
     - name: Build Lua Server-side SDK with Redis
       shell: bash
+      # {x-release-please-start-version}
       run: |
         luarocks make ${{ steps.rockspec-pkg-name.outputs.server_redis }} \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release
+      # {x-release-please-end}
 
     - name: Run Lua Server-side SDK Tests
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -97,8 +97,24 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
 
     - name: Run hello-lua-server example
+      if: ${{ ! contains(inputs.lua-version, 'jit') }}
       shell: bash
       env:
         LD_SDK_KEY: "fake-sdk-key"
+        # Needed because boost isn't installed in default system paths, which is
+        # what the C++ Server-side SDK shared object expects.
+        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
       run: |
         lua ./examples/hello-lua-server/hello.lua
+        
+
+    - name: Run hello-lua-server example (JIT)
+      if: ${{ contains(inputs.lua-version, 'jit') }}
+      shell: bash
+      env:
+        LD_SDK_KEY: "fake-sdk-key"
+        # Needed because boost isn't installed in default system paths, which is
+        # what the C++ Server-side SDK shared object expects.
+        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
+      run: |
+        luajit ./examples/hello-lua-server/hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -97,7 +97,7 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
 
     - name: Run hello-lua-server example
-      if: ${{ ! contains(inputs.lua-version, 'jit') }}
+      if: ${{ !contains(inputs.lua-version, 'jit') }}
       shell: bash
       env:
         LD_SDK_KEY: "fake-sdk-key"

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -95,3 +95,10 @@ runs:
         # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled
         # with the SDK release.
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
+
+    - name: Run hello-lua-server example
+      shell: bash
+      env:
+        LD_SDK_KEY: "fake-sdk-key"
+      run: |
+        lua ./examples/hello-lua-server/hello.lua

--- a/examples/hello-lua-server/hello.lua
+++ b/examples/hello-lua-server/hello.lua
@@ -1,7 +1,7 @@
 local ld = require("launchdarkly_server_sdk")
 
 -- Allows the LaunchDarkly SDK key to be specified as an environment variable (LD_SDK_KEY)
--- or locally in this example code.
+-- or locally in this example code (YOUR_SDK_KEY).
 function get_key_from_env_or(existing_key)
     if existing_key ~= "" then
         return existing_key

--- a/examples/hello-lua-server/hello.lua
+++ b/examples/hello-lua-server/hello.lua
@@ -1,0 +1,37 @@
+local ld = require("launchdarkly_server_sdk")
+
+-- Allows the LaunchDarkly SDK key to be specified as an environment variable (LD_SDK_KEY)
+-- or locally in this example code.
+function get_key_from_env_or(existing_key)
+    if existing_key ~= "" then
+        return existing_key
+    end
+
+    local env_key = os.getenv("LD_SDK_KEY")
+    if env_key ~= "" then
+        return env_key
+    end
+
+    error("No SDK key specified (use LD_SDK_KEY environment variable or set local YOUR_SDK_KEY)")
+end
+
+-- Set YOUR_SDK_KEY to your LaunchDarkly SDK key.
+local YOUR_SDK_KEY = ""
+
+-- Set YOUR_FEATURE_KEY to the feature flag key you want to evaluate.
+local YOUR_FEATURE_KEY = "my-boolean-flag"
+
+
+local config = {}
+
+local client = ld.clientInit(get_key_from_env_or(YOUR_SDK_KEY), 1000, config)
+
+local user = ld.makeContext({
+    user = {
+        key = "example-user-key",
+        name = "Sandy"
+    }
+})
+
+local value = client:boolVariation(user, YOUR_FEATURE_KEY, false)
+print("feature flag "..YOUR_FEATURE_KEY.." is "..tostring(value).." for this user")


### PR DESCRIPTION
This incorporates a hello-lua example directly into the repo, allowing us to archive [hello-lua-server](https://github.com/launchdarkly/hello-lua-server).

I'm labeling this as a fix because it should have been included in the first release - this shouldn't trigger a minor version, but it's still helpful to test the release process with a patch.