### PR TITLE
ci: update rockspec version to match released version

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -3,7 +3,20 @@ description: 'Shared CI workflow.'
 inputs:
   lua-version:
     description: 'Version of Lua to use for building and testing.'
-    required: true
+    required: false
+    default: '5.3'
+  lua-server-version:
+    description: 'Version of the Lua Server-side SDK to use for building and testing.'
+    required: false
+    default: "2.0.0" # {x-release-please-version}
+  lua-server-redis-version:
+    description: 'Version of the Lua Server-side SDK with Redis to use for building and testing.'
+    required: false
+    default: "2.0.0" # {x-release-please-version}
+  cpp-sdk-version:
+    description: 'Version of the C++ Server-side SDK to use for building and testing.'
+    required: false
+    default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
 
 runs:
   using: composite
@@ -23,25 +36,32 @@ runs:
     - name: Install CPP SDK
       uses: ./.github/actions/install-cpp-sdk-redis
       with:
-          version: launchdarkly-cpp-server-redis-source-v2.1.0
+          version: ${{ inputs.cpp-sdk-version }}
           path: cpp-sdk
+
+    - name: Construct rockspec package name
+      id: rockspec-pkg-name
+      shell: bash
+      run: |
+          echo "server=launchdarkly-server-sdk-${{ inputs.lua-server-version }}-0.rockspec" >> $GITHUB_OUTPUT
+          echo "server_redis=launchdarkly-server-sdk-redis-${{ inputs.lua-server-redis-version }}-0.rockspec" >> $GITHUB_OUTPUT
 
     - name: Build Lua Server-side SDK
       shell: bash
       run:  |
-        luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
+        luarocks make ${{ steps.rockspec-pkg-name.outputs.server }} \
         LD_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Build Lua Server-side SDK with Redis
       shell: bash
       run: |
-        luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
+        luarocks make ${{ steps.rockspec-pkg-name.outputs.server_redis }} \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Run Lua Server-side SDK Tests
       shell: bash
       if: ${{ ! contains(inputs.lua-version, 'jit') }}
-      run: luarocks test launchdarkly-server-sdk-1.0-0.rockspec
+      run: luarocks test ${{ steps.rockspec-pkg-name.outputs.server }}
       env:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects.
@@ -59,7 +79,7 @@ runs:
     - name: Run Lua Server-side SDK with Redis Tests
       shell: bash
       if: ${{ ! contains(inputs.lua-version, 'jit') }}
-      run: luarocks test launchdarkly-server-sdk-redis-1.0-0.rockspec
+      run: luarocks test ${{ steps.rockspec-pkg-name.outputs.server_redis }}
       env:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Build and Test
         uses: ./.github/actions/ci
-        with:
-          lua-version: "5.3"
 
       - name: Build documentation
         uses: ./.github/actions/build-docs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Build and Test
         if: ${{ steps.release.outputs.release_created }}
         uses: ./.github/actions/ci
-        with:
-          lua-version: "5.3"
 
       - name: Build documentation
         if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ To compile the LuaRock modules:
 3. Run `luarocks make` (replace the version number as necessary):
     ```bash
     # Base SDK
-    luarocks make launchdarkly-server-sdk-1.0-0.rockspec \
+    luarocks make launchdarkly-server-sdk-2.0.0-0.rockspec \
     LD_DIR=./path-to-installed-cpp-sdk
 
     # SDK with Redis
-    luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec \
+    luarocks make launchdarkly-server-sdk-redis-2.0.0-0.rockspec \
     LDREDIS_DIR=./path-to-installed-cpp-sdk
     ```
 

--- a/launchdarkly-server-sdk-2.0.0-0.rockspec
+++ b/launchdarkly-server-sdk-2.0.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk"
 
 rockspec_format = "3.0"
 
-version = "1.0-0"
+version = "2.0.0-0"
 
 description = {
    summary = "LaunchDarkly Lua Server-Side SDK",

--- a/launchdarkly-server-sdk-redis-2.0.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-2.0.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk-redis"
 
 rockspec_format = "3.0"
 
-version = "1.0-0"
+version = "2.0.0-0"
 
 description = {
    summary = "LaunchDarkly Lua Server-Side SDK Redis Source",

--- a/launchdarkly-server-sdk.c
+++ b/launchdarkly-server-sdk.c
@@ -1061,9 +1061,9 @@ makeConfig(lua_State *const l, const char *const sdk_key)
 Initialize a new client, and connect to LaunchDarkly.
 Applications should instantiate a single instance for the lifetime of their application.
 
-@function initClient
+@function clientInit
 @param string Environment SDK key
-@param int Initialization timeout in milliseconds. initClient will
+@param int Initialization timeout in milliseconds. clientInit will
 block for this long before returning a non-fully initialized client. Pass 0 to return
 immediately without waiting (note that the client will continue initializing in the background.)
 @tparam table config list of configuration options

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "bump-minor-pre-major": true,
       "versioning": "default",
       "extra-files": [
-        "launchdarkly-server-sdk.c"
+        "launchdarkly-server-sdk.c",
+        ".github/actions/ci.yml"
       ]
     }
   }


### PR DESCRIPTION
This updates the existing `.rockspec`'s to match our currently released `2.0.0` version. 

Additionally, I've refactored the `ci` workflow to take the rockspec package names as inputs. Otherwise when the versions rev, our CI will break since it's currently hardcoded to `1.0`. 


docs: fix mis-named clientInit method