### PR TITLE
ci: use release-please to hardcode the version in version-updater.sh

### DIFF
--- a/.github/actions/update-versions/action.yml
+++ b/.github/actions/update-versions/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   version:
     description: 'The semantic version to use'
-    required: true
+    required: false
+    default: 'auto'
   package:
     description: 'The rockspec package to update'
     required: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,29 +23,19 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}
 
-      - name: Determine semantic version and PR branch from release-please output
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        id: release-metadata
-        shell: bash
-        run: |
-          echo "semver=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}" >> $GITHUB_OUTPUT
-          echo "branch=${{ fromJSON(steps.release.outputs.pr).headBranchName }}" >> $GITHUB_OUTPUT
-
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions
         if: ${{ steps.release-metadata.outcome == 'success' }}
         with:
           package: launchdarkly-server-sdk
-          branch: ${{ steps.release-metadata.outputs.branch }}
-          version: ${{ steps.release-metadata.outputs.semver }}
+          branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
       - name: Update launchdarkly-server-sdk-redis rockspec
         uses: ./.github/actions/update-versions
         if: ${{ steps.release-metadata.outcome == 'success' }}
         with:
           package: launchdarkly-server-sdk-redis
-          branch: ${{ steps.release-metadata.outputs.branch }}
-          version: ${{ steps.release-metadata.outputs.semver }}
+          branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
       - name: Build and Test
         if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To compile the LuaRock modules:
 1. Install [LuaRocks](https://github.com/luarocks/luarocks/wiki/Download)
 2. Build the [C++ Server-side SDK](https://github.com/launchdarkly/cpp-sdks) from source using CMake, or obtain pre-built artifacts from the [releases page](https://github.com/launchdarkly/cpp-sdks/releases?q=%22launchdarkly-cpp-server%22)
 3. Run `luarocks make` (replace the version number as necessary):
+    <!-- x-release-please-start-version -->
     ```bash
     # Base SDK
     luarocks make launchdarkly-server-sdk-2.0.0-0.rockspec \
@@ -61,6 +62,7 @@ To compile the LuaRock modules:
     luarocks make launchdarkly-server-sdk-redis-2.0.0-0.rockspec \
     LDREDIS_DIR=./path-to-installed-cpp-sdk
     ```
+    <!-- x-release-please-end -->
 
 Please note that the Lua SDK uses the C++ server-side SDK's C bindings, so if you're using prebuilt artifacts
 then only a C99 compiler is necessary.

--- a/launchdarkly-server-sdk-2.0.0-0.rockspec
+++ b/launchdarkly-server-sdk-2.0.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk"
 
 rockspec_format = "3.0"
 
-version = "2.0.0-0"
+version = "2.0.0-0" -- {x-release-please-version}
 
 description = {
    summary = "LaunchDarkly Lua Server-Side SDK",
@@ -20,7 +20,7 @@ description = {
 
 source = {
    url = "git+https://github.com/launchdarkly/lua-server-sdk.git",
-   tag = "v2.0.0"
+   tag = "v2.0.0" -- {x-release-please-version}
 }
 
 dependencies = {

--- a/launchdarkly-server-sdk-redis-2.0.0-0.rockspec
+++ b/launchdarkly-server-sdk-redis-2.0.0-0.rockspec
@@ -2,7 +2,7 @@ package = "launchdarkly-server-sdk-redis"
 
 rockspec_format = "3.0"
 
-version = "2.0.0-0"
+version = "2.0.0-0" -- {x-release-please-version}
 
 description = {
    summary = "LaunchDarkly Lua Server-Side SDK Redis Source",
@@ -19,7 +19,7 @@ description = {
 
 source = {
    url = "git+https://github.com/launchdarkly/lua-server-sdk.git",
-   tag = "v2.0.0"
+   tag = "v2.0.0" -- {x-release-please-version}
 }
 
 dependencies = {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "versioning": "default",
       "extra-files": [
         "launchdarkly-server-sdk.c",
-        ".github/actions/ci.yml"
+        ".github/actions/ci/action.yml"
       ]
     }
   }

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-# This script has two responsibilities:
-# 1. Update the package version in the rockspec file.
-# 2. Update the actual filename of the rockspec file.
-# These two should match.
+# This script renames a rockspec file containing one semantic version to another.
 # This script doesn't update the rockspec version - the part after the package version, but before the .rockspec
 # suffix. That should be done manually if the rockspec itself has changed but not the package contents.
 #
@@ -21,13 +18,17 @@ input_version=$2
 git_username=$3
 git_email=$4
 
+# If input_version isn't set, then hardcode it (updated by release-please in CI)
+if [ -z "$input_version" ]; then
+    input_version="2.0.0" # { x-release-please-version }
+fi
+
 autocommit=''
 if [ -n "$git_username" ] || [ -n "$git_email" ]; then
     autocommit=1
 fi
 
-# Ensure autocommit if provided is
-if [ -z "$input_rockspec" ] || [ -z "$input_version" ]; then
+if [ -z "$input_rockspec" ]; then
     echo "Usage: $0 <rockspec package> <new version> [git username] [git email]"
     echo "Example usage locally: $0 launchdarkly-server-sdk 1.2.0"
     echo "Example usage in CI: $0 launchdarkly-server-sdk 1.2.0 LaunchDarklyReleaseBot LaunchDarklyReleaseBot@launchdarkly.com"
@@ -68,23 +69,7 @@ for file in "$input_rockspec"-*.rockspec; do
     new_file_name="$input_rockspec-$input_version-$rockspec_revision.rockspec"
     git mv "$file" "$new_file_name"
     echo "Renamed $file to $new_file_name"
-
-    # Update the 'version' field with the new semver.
-    sed -i.bak "s/version = \".*\"/version = \"$input_version-$rockspec_revision\"/" "$new_file_name"
-    echo "Bumped version from $semver to $input_version"
-
-    # Update the 'tag' field to contain the git tag, which we're hardcoding as 'v' + the version number. This
-    # relies on the assumption that our release please config specifies a leading v.
-    sed -i.bak "s/tag = \".*\"/tag = \"v$input_version\"/" "$new_file_name"
-    echo "Updated source.tag to v$input_version"
-
     rm -f "$new_file_name.bak"
-
-    # Update README.md to replace $file with the new filename, which will result in the codesample having the new
-    # version number.
-    sed -i.bak "s/$file/$new_file_name/" README.md
-    echo "Updated README.md code example"
-    rm -f README.md.bak
 
     if [ "$(git status --porcelain | wc -l)" -gt 0 ]; then
       if [ -n "$git_username" ]; then
@@ -96,7 +81,7 @@ for file in "$input_rockspec"-*.rockspec; do
       git add "$new_file_name"
       git add README.md
       if [ $autocommit ]; then
-        git commit -m "chore: bump $input_rockspec version from $semver to $input_version and update README"
+        git commit -m "chore: rename $input_rockspec version from $semver to $input_version"
         git push
       else
         echo "Changes staged, but not committed. Please commit manually."

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -18,8 +18,7 @@ input_version=$2
 git_username=$3
 git_email=$4
 
-# If input_version isn't set, then hardcode it (updated by release-please in CI)
-if [ -z "$input_version" ]; then
+if [ "$input_version" == "auto" ]; then
     input_version="2.0.0" # { x-release-please-version }
 fi
 
@@ -28,10 +27,10 @@ if [ -n "$git_username" ] || [ -n "$git_email" ]; then
     autocommit=1
 fi
 
-if [ -z "$input_rockspec" ]; then
-    echo "Usage: $0 <rockspec package> <new version> [git username] [git email]"
+if [ -z "$input_rockspec" ] || [ -z "$input_version" ]; then
+    echo "Usage: $0 <rockspec package> <new version|auto> [git username] [git email]"
     echo "Example usage locally: $0 launchdarkly-server-sdk 1.2.0"
-    echo "Example usage in CI: $0 launchdarkly-server-sdk 1.2.0 LaunchDarklyReleaseBot LaunchDarklyReleaseBot@launchdarkly.com"
+    echo "Example usage in CI: $0 launchdarkly-server-sdk auto LaunchDarklyReleaseBot LaunchDarklyReleaseBot@launchdarkly.com"
     echo "Providing a git username and email will automatically commit & push any changes."
     exit 1
 fi


### PR DESCRIPTION
This hardcodes (using `x-release-please-version`) the proper version in `./scripts/version-updater.sh`.

This also uses `x-release-please-version` for the README and the internal version numbers of the `rockspec`'s - previously this wasn't the case because I thought it might not work.

I'm hoping it is smart enough to deal with the `-0` suffix in the line that it is updating.