### PR TITLE
ci: use explicit comparison to string 'true' in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,31 +21,31 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.prs_created }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
 
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.release.outputs.prs_created }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
           package: launchdarkly-server-sdk
           branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
       - name: Update launchdarkly-server-sdk-redis rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.release.outputs.prs_created }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
           package: launchdarkly-server-sdk-redis
           branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
       - name: Build and Test
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         uses: ./.github/actions/ci
 
       - name: Build documentation
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         uses: ./.github/actions/build-docs
 
       - uses: ./.github/actions/publish-docs
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Step outputs are cast to strings. So `false` == `'false'`, and `true == 'true'`.

Right now the `'false'` is output from release-please's `prs_created`. And in an expression, that is evaluated as `true`. Because it's a non-empty string, I think?

Instead, compare against the actual string 'true'. 