### PR TITLE
fix: after update tag to 2.0.1 rockspec was also updated

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -4,5 +4,5 @@
 # the paths fetched by ./get-cpp-sdk-locally.sh.
 
 set -e
-luarocks make launchdarkly-server-sdk-1.0-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
-luarocks make launchdarkly-server-sdk-redis-1.0-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL
+luarocks make launchdarkly-server-sdk-2.0.1-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
+luarocks make launchdarkly-server-sdk-redis-2.0.1-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

No related issues

**Describe the solution you've provided**

After updating tag to 2.0.1, rockspec was also updated, but the compile script was not.

**Describe alternatives you've considered**

Update compile script to read the new version of the rockspec.

**Additional context**

Found it after trying to compile it again with the new update version.
