### PR TITLE
chore: update compile.sh with release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
         "launchdarkly-server-sdk.c",
         ".github/actions/ci/action.yml",
         "README.md",
-        "scripts/update-versions.sh"
+        "scripts/update-versions.sh",
+        "scripts/compile.sh"
       ]
     }
   }

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -4,5 +4,8 @@
 # the paths fetched by ./get-cpp-sdk-locally.sh.
 
 set -e
-luarocks make launchdarkly-server-sdk-2.0.1-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
-luarocks make launchdarkly-server-sdk-redis-2.0.1-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL
+
+version="2.0.1" # {x-release-please-version }
+
+luarocks make launchdarkly-server-sdk-$version-0.rockspec LD_DIR=./cpp-sdks/build/INSTALL
+luarocks make launchdarkly-server-sdk-redis-$version-0.rockspec LDREDIS_DIR=./cpp-sdks/build/INSTALL


### PR DESCRIPTION
Adds `compile.sh` to `extra-files`. This script is used to compile both base+redis SDKs locally for convenience.