### PR TITLE
ci: always checkout code when running release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
 
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions


### PR DESCRIPTION
The `release-please` workflow is slightly complicated in that it has two phases - stuff to run when there's a release PR, and stuff to run if a release was actually created.

The `actions/checkout` only ran if `prs_created == 'true'`. 

This means that when the release PR was merged, it wouldn't run - and therefore the post-release steps couldn't succeed. This removes the guard so the repo is always checked out. 
