### PR TITLE
ci: add manual publish to LuaRocks

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -5,18 +5,11 @@ inputs:
     description: 'Version of Lua to use for building and testing.'
     required: false
     default: '5.3'
-  lua-server-version:
-    description: 'Version of the Lua Server-side SDK to use for building and testing.'
-    required: false
-    default: "2.0.2" # {x-release-please-version}
-  lua-server-redis-version:
-    description: 'Version of the Lua Server-side SDK with Redis to use for building and testing.'
-    required: false
-    default: "2.0.2" # {x-release-please-version}
   cpp-sdk-version:
     description: 'Version of the C++ Server-side SDK to use for building and testing.'
     required: false
     default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
+
 
 runs:
   using: composite
@@ -39,29 +32,25 @@ runs:
           version: ${{ inputs.cpp-sdk-version }}
           path: cpp-sdk
 
-    - name: Construct rockspec package name
-      id: rockspec-pkg-name
-      shell: bash
-      run: |
-          echo "server=launchdarkly-server-sdk-${{ inputs.lua-server-version }}-0.rockspec" >> $GITHUB_OUTPUT
-          echo "server_redis=launchdarkly-server-sdk-redis-${{ inputs.lua-server-redis-version }}-0.rockspec" >> $GITHUB_OUTPUT
+    - uses: ./.github/actions/rockspec-names
+      id: rockspecs
 
     - name: Build Lua Server-side SDK
       shell: bash
       run:  |
-        luarocks make ${{ steps.rockspec-pkg-name.outputs.server }} \
+        luarocks make ${{ steps.rockspecs.outputs.server }} \
         LD_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Build Lua Server-side SDK with Redis
       shell: bash
       run: |
-        luarocks make ${{ steps.rockspec-pkg-name.outputs.server_redis }} \
+        luarocks make ${{ steps.rockspecs.outputs.server_redis }} \
         LDREDIS_DIR=./cpp-sdk/build-dynamic/release
 
     - name: Run Lua Server-side SDK Tests
       shell: bash
       if: ${{ ! contains(inputs.lua-version, 'jit') }}
-      run: luarocks test ${{ steps.rockspec-pkg-name.outputs.server }}
+      run: luarocks test ${{ steps.rockspecs.outputs.server }}
       env:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects.
@@ -79,7 +68,7 @@ runs:
     - name: Run Lua Server-side SDK with Redis Tests
       shell: bash
       if: ${{ ! contains(inputs.lua-version, 'jit') }}
-      run: luarocks test ${{ steps.rockspec-pkg-name.outputs.server_redis }}
+      run: luarocks test ${{ steps.rockspecs.outputs.server_redis }}
       env:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects. Same for hiredis which is bundled

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,0 +1,24 @@
+name: Publish Package
+description: 'Publish the package to LuaRocks'
+inputs:
+  dry_run:
+    description: "Whether to perform a dry run. If true, the package won't be published."
+    required: false
+    default: 'false'
+  rockspec:
+    description: "The name of the rockspec file to publish."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Pack rock
+      shell: bash
+      run: luarocks pack ${{ inputs.rockspec }}
+    - name: Upload rock
+      if: ${{ inputs.dry_run == 'false' }}
+      shell: bash
+      env:
+        API_TOKEN: ${{ env.LUAROCKS_API_TOKEN }}
+      run: |
+        luarocks upload ${{ inputs.rockspec }} --api-key "$API_TOKEN"

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -18,7 +18,5 @@ runs:
     - name: Upload rock
       if: ${{ inputs.dry_run == 'false' }}
       shell: bash
-      env:
-        API_TOKEN: ${{ env.LUAROCKS_API_TOKEN }}
       run: |
-        luarocks upload ${{ inputs.rockspec }} --api-key "$API_TOKEN"
+        luarocks upload ${{ inputs.rockspec }} --api-key "$LUAROCKS_API_TOKEN"

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -8,6 +8,15 @@ inputs:
   rockspec:
     description: "The name of the rockspec file to publish."
     required: true
+  skip_pack:
+    description: "Whether the uploaded package should contain only the rockspec file, or source as well."
+    required: false
+    default: 'false'
+  force:
+    description: "Whether to force the upload of the package, even if it already exists."
+    required: false
+    default: 'false'
+
 
 runs:
   using: composite
@@ -19,4 +28,11 @@ runs:
       if: ${{ inputs.dry_run == 'false' }}
       shell: bash
       run: |
-        luarocks upload ${{ inputs.rockspec }} --api-key "$LUAROCKS_API_TOKEN"
+        command="luarocks upload ${{ inputs.rockspec }} --api-key $LUAROCKS_API_TOKEN"
+        if [ "${{ inputs.force }}" == "true" ] ; then
+          command="$command --force"
+        fi
+        if [ "${{ inputs.skip_pack }}" == "true" ] ; then
+          command="$command --skip_pack"
+        fi
+        eval "$command"

--- a/.github/actions/rockspec-names/action.yml
+++ b/.github/actions/rockspec-names/action.yml
@@ -1,17 +1,17 @@
 name: Get Rockspec Names
-description: 'Generates proper rockspec package names for base and redis variants of the server SDK.'
+description: 'Generates proper rockspec package names for SDK and redis integration'
 outputs:
   server:
-    description: "The name of the base server rockspec package."
+    description: "The name of the server rockspec package."
     value: ${{ steps.pkg-name.outputs.server }}
   server_redis:
-    description: "The name of the redis server rockspec package."
+    description: "The name of the redis rockspec package."
     value: ${{ steps.pkg-name.outputs.server_redis }}
 
 runs:
   using: composite
   steps:
-    - name: Construct rockspec package name
+    - name: Construct rockspec package names
       id: pkg-name
       shell: bash
       env:
@@ -19,4 +19,4 @@ runs:
         LUA_SERVER_REDIS_VERSION: "2.0.2" # {x-release-please-version}
       run: |
         echo "server=launchdarkly-server-sdk-${{ env.LUA_SERVER_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT
-        echo "server_redis=launchdarkly-server-sdk-redis-${{ inputs.LUA_SERVER_REDIS_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT
+        echo "server_redis=launchdarkly-server-sdk-redis-${{ env.LUA_SERVER_REDIS_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT

--- a/.github/actions/rockspec-names/action.yml
+++ b/.github/actions/rockspec-names/action.yml
@@ -1,0 +1,22 @@
+name: Get Rockspec Names
+description: 'Generates proper rockspec package names for base and redis variants of the server SDK.'
+outputs:
+  server:
+    description: "The name of the base server rockspec package."
+    value: ${{ steps.pkg-name.outputs.server }}
+  server_redis:
+    description: "The name of the redis server rockspec package."
+    value: ${{ steps.pkg-name.outputs.server_redis }}
+
+runs:
+  using: composite
+  steps:
+    - name: Construct rockspec package name
+      id: pkg-name
+      shell: bash
+      env:
+        LUA_SERVER_VERSION: "2.0.2"  # {x-release-please-version}
+        LUA_SERVER_REDIS_VERSION: "2.0.2" # {x-release-please-version}
+      run: |
+        echo "server=launchdarkly-server-sdk-${{ env.LUA_SERVER_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT
+        echo "server_redis=launchdarkly-server-sdk-redis-${{ inputs.LUA_SERVER_REDIS_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # If you only need the current version keep this.
-
       - uses: ./.github/actions/ci
         with:
           lua-version: ${{ matrix.version }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -9,11 +9,21 @@ on:
         default: true
       rockspec:
         type: choice
-        description: 'Whether to publish the server SDK or redis integration'
+        description: 'Whether to publish the server SDK or redis integration (or both)'
         options:
           - server
           - redis
-
+          - both
+      skip_pack:
+        description: "Whether the uploaded package should contain only the rockspec file, or source as well."
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: "Whether to force the upload of the package, even if it already exists."
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build-publish:
@@ -39,14 +49,18 @@ jobs:
 
       - uses: ./.github/actions/publish
         name: "Publish Lua Server SDK"
-        if: ${{ inputs.rockspec == 'server' }}
+        if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ steps.rockspecs.outputs.server }}
+          skip_pack: ${{ inputs.skip_pack }}
+          force: ${{ inputs.force }}
 
       - uses: ./.github/actions/publish
         name: "Publish Lua Server SDK's Redis Integration"
-        if: ${{ inputs.rockspec == 'redis' }}
+        if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both'}}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ steps.rockspecs.outputs.server_redis }}
+          skip_pack: ${{ inputs.skip_pack }}
+          force: ${{ inputs.force }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,0 +1,52 @@
+name: Publish Package
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Whether to perform a dry run. If true, the package won't be published."
+        type: boolean
+        required: false
+        default: true
+      rockspec:
+        type: choice
+        description: 'Whether to publish the base server or redis package'
+        options:
+          - server
+          - server_redis
+
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+
+    # Needed for AWS SSM access.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
+        name: 'Get LuaRocks token'
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+
+      - uses: ./.github/actions/ci
+
+      - uses: ./.github/rockspec-names
+        id: rockspecs
+
+      - uses: ./.github/actions/publish
+        name: "Publish Lua Server SDK"
+        if: ${{ inputs.rockspec == 'server' }}
+        with:
+          dry_run: ${{ inputs.dry_run }}
+          rockspec: ${{ steps.rockspecs.outputs.server }}
+
+      - uses: ./.github/actions/publish
+        name: "Publish Lua Server SDK's Redis Integration"
+        if: ${{ inputs.rockspec == 'server_redis' }}
+        with:
+          dry_run: ${{ inputs.dry_run }}
+          rockspec: ${{ steps.rockspecs.outputs.server_redis }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -9,10 +9,10 @@ on:
         default: true
       rockspec:
         type: choice
-        description: 'Whether to publish the base server or redis package'
+        description: 'Whether to publish the server SDK or redis integration'
         options:
           - server
-          - server_redis
+          - redis
 
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/publish
         name: "Publish Lua Server SDK's Redis Integration"
-        if: ${{ inputs.rockspec == 'server_redis' }}
+        if: ${{ inputs.rockspec == 'redis' }}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ steps.rockspecs.outputs.server_redis }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "versioning": "default",
       "extra-files": [
         "launchdarkly-server-sdk.c",
-        ".github/actions/ci/action.yml",
+        ".github/actions/rockspec-names/action.yml",
         "README.md",
         "scripts/update-versions.sh",
         "scripts/compile.sh"


### PR DESCRIPTION
Adds a manual publishing workflow for LuaRocks. Once I've proved it actually works, we can add it to the `release-please` workflow. 

Note: this won't work until the AWS role variable is present in the repo configuration.

