### PR TITLE
ci: fix action filepath in manual-publish workflow

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: ./.github/actions/ci
 
-      - uses: ./.github/rockspec-names
+      - uses: ./.github/actions/rockspec-names
         id: rockspecs
 
       - uses: ./.github/actions/publish


### PR DESCRIPTION
Filepath was wrong for the manual publish workflow's invocation of the `rockspec-names` action.