### PR TITLE
ci: install lua-cjson in publish step

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -21,6 +21,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install lua-cjson
+      shell: bash
+      run: luarocks install lua-cjson # needed for 'luarocks upload' command
     - name: Pack rock
       shell: bash
       run: luarocks pack ${{ inputs.rockspec }}


### PR DESCRIPTION
Looks like luarocks upload has a dependency on having a `json` library installed. This adds a `luarocks install lua-cjson` call.