### PR TITLE
ci: improve UX of manual publish step

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -2,25 +2,25 @@ name: Publish Package
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: "Whether to perform a dry run. If true, the package won't be published."
-        type: boolean
-        required: false
-        default: true
       rockspec:
         type: choice
-        description: 'Whether to publish the server SDK or redis integration (or both)'
+        description: 'What to publish?'
         options:
           - server
           - redis
           - both
+      dry_run:
+        description: "Dry run? If checked, don't publish."
+        type: boolean
+        required: false
+        default: true
       skip_pack:
-        description: "Whether the uploaded package should contain only the rockspec file, or source as well."
+        description: "Don't include source rock? If checked, only publish rockspec."
         required: false
         type: boolean
         default: false
       force:
-        description: "Whether to force the upload of the package, even if it already exists."
+        description: "Overwrite existing version?"
         type: boolean
         required: false
         default: false


### PR DESCRIPTION
The description of options in the manual publish step are a bit verbose. This shortens them and makes them easier to read.