### PR TITLE
chore(deps): make redis rockspec depend on base server SDK

### DIFF
--- a/launchdarkly-server-sdk-2.0.2-0.rockspec
+++ b/launchdarkly-server-sdk-2.0.2-0.rockspec
@@ -5,9 +5,9 @@ rockspec_format = "3.0"
 version = "2.0.2-0"
 
 description = {
-   summary = "LaunchDarkly Lua Server-Side SDK",
+   summary = "LaunchDarkly SDK for server-side applications.",
    detailed = [[
-      The Lua Server-Side SDK provides access to LaunchDarkly's feature flag system and is suitable for
+      The Lua Server-side SDK provides access to LaunchDarkly's feature flag system and is suitable for
       server-side application. It is a wrapper around the LaunchDarkly C++ Server-side SDK, making use of its
       C API.
    ]],

--- a/launchdarkly-server-sdk-redis-2.0.2-0.rockspec
+++ b/launchdarkly-server-sdk-redis-2.0.2-0.rockspec
@@ -23,7 +23,8 @@ source = {
 }
 
 dependencies = {
-   "lua >= 5.1, <= 5.4"
+   "lua >= 5.1, <= 5.4",
+   "launchdarkly-server-sdk ~> 2"
 }
 
 external_dependencies = {

--- a/launchdarkly-server-sdk-redis-2.0.2-0.rockspec
+++ b/launchdarkly-server-sdk-redis-2.0.2-0.rockspec
@@ -5,9 +5,9 @@ rockspec_format = "3.0"
 version = "2.0.2-0"
 
 description = {
-   summary = "LaunchDarkly Lua Server-Side SDK Redis Source",
+   summary = "Redis integration for LaunchDarkly Lua Server-side SDK.",
    detailed = [[
-      Provides a Redis-based data source for the LaunchDarkly Lua Server-Side SDK. Use this if your feature flags
+      Provides a Redis data source for the LaunchDarkly Lua Server-Side SDK. Use this if your feature flags
       should be retrieved from Redis instead of LaunchDarkly SaaS (for instance, when using Relay Proxy.)
    ]],
    license = "Apache-2.0",


### PR DESCRIPTION
Now that we have a published luarocks module, we can have the redis rockspec depend on the base server.