### PR TITLE
ci: add installation test after publishing package

### DIFF
--- a/.github/actions/install-cpp-sdk-redis/action.yml
+++ b/.github/actions/install-cpp-sdk-redis/action.yml
@@ -1,13 +1,10 @@
-# This custom action is used because the MarkusJx/install-boost does
-# not include all built libraries for mac or windows builds.
-# Specifically, it was missing boost_json.
 name: Install C++ Server-side SDK with Redis Source
 description: 'Obtain prebuilt libraries for the Launchdarkly C++ server-side SDK with Redis Source.'
 inputs:
     version:
         required: true
         description: "Version of the C++ SDK with Redis Source."
-        default: "v1.0.1"
+        default: "launchdarkly-cpp-server-redis-source-v2.1.0"
     path:
       description: "Where to download the SDK."
       default: "cpp-sdk"

--- a/.github/actions/rockspec-names/action.yml
+++ b/.github/actions/rockspec-names/action.yml
@@ -7,6 +7,12 @@ outputs:
   server_redis:
     description: "The name of the redis rockspec package."
     value: ${{ steps.pkg-name.outputs.server_redis }}
+  server_version:
+    description: "The version of the server rockspec package."
+    value: ${{ steps.pkg-name.outputs.server_version }}
+  server_redis_version:
+    description: "The version of the redis rockspec package."
+    value: ${{ steps.pkg-name.outputs.server_redis_version }}
 
 runs:
   using: composite
@@ -20,3 +26,5 @@ runs:
       run: |
         echo "server=launchdarkly-server-sdk-${{ env.LUA_SERVER_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT
         echo "server_redis=launchdarkly-server-sdk-redis-${{ env.LUA_SERVER_REDIS_VERSION }}-0.rockspec" >> $GITHUB_OUTPUT
+        echo "server_version=${{ env.LUA_SERVER_VERSION }}" >> $GITHUB_OUTPUT
+        echo "server_redis_version=${{ env.LUA_SERVER_REDIS_VERSION }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -1,0 +1,72 @@
+name: 'Install Lua SDK'
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to install.'
+        required: false
+        type: choice
+        options:
+          - 'launchdarkly-server-sdk'
+          - 'launchdarkly-server-sdk-redis'
+        default: 'launchdarkly-server-sdk'
+      version:
+        description: 'Version to install. Default is latest.'
+        required: false
+        type: string
+
+      lua-version:
+        description: 'Lua version.'
+        required: false
+        type: choice
+        options:
+          - '5.1'
+          - '5.2'
+          - '5.3'
+          - '5.4'
+          - 'luajit-2.0.5'
+        default: '5.4'
+      cpp-sdk-version:
+        description: "Version of the C++ Server-side SDK to use for building and testing."
+        required: false
+        type: string
+        default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Lua
+        uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e
+        with:
+          luaVersion: ${{ inputs.lua-version }}
+
+      - name: Install LuaRocks
+        uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5
+
+      - name: Install Boost
+        id: install-boost
+        uses: MarkusJx/install-boost@v2.4.4
+        with:
+          boost_version: 1.81.0
+          platform_version: "22.04"
+
+      - name: Install CPP SDK
+        uses: ./.github/actions/install-cpp-sdk-redis
+        with:
+          version: ${{ inputs.cpp-sdk-version }}
+          path: cpp-sdk
+
+      - name: Install Package
+        shell: bash
+        env:
+          CPP_PATH: $GITHUB_WORKSPACE/cpp-sdk/build-dynamic/release
+        run: |
+          luarocks install ${{ inputs.package }} ${{ inputs.version }} \
+          LD_DIR=$CPP_PATH \
+          LDREDIS_DIR=$CPP_PATH
+
+      - name: Remove Package
+        shell: bash
+        run: luarocks remove ${{ inputs.package }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -48,7 +48,7 @@ jobs:
         id: rockspecs
 
       - uses: ./.github/actions/publish
-        name: "Publish Lua Server SDK"
+        name: ${{ format('Publish launchdarkly-server-sdk @ {0}', steps.rockspecs.outputs.server_version) }}
         if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
         with:
           dry_run: ${{ inputs.dry_run }}
@@ -57,10 +57,28 @@ jobs:
           force: ${{ inputs.force }}
 
       - uses: ./.github/actions/publish
-        name: "Publish Lua Server SDK's Redis Integration"
+        name: ${{ format('Publish launchdarkly-server-sdk-redis @ {0}', steps.rockspecs.outputs.server_redis_version) }}
         if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both'}}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ steps.rockspecs.outputs.server_redis }}
           skip_pack: ${{ inputs.skip_pack }}
           force: ${{ inputs.force }}
+
+  install-server-sdk:
+    name: ${{ format('Install launchdarkly-server-sdk @ {0}', steps.rockspecs.outputs.server_version) }}
+    needs: build-publish
+    if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
+    uses: ./github/workflows/install-lua-sdk.yml
+    with:
+      package: launchdarkly-server-sdk
+      version: ${{ steps.rockspecs.outputs.server_version }}
+
+  install-server-redis:
+    name: ${{ format('Install launchdarkly-server-sdk-redis @ {0}', steps.rockspecs.outputs.server_redis_version) }}
+    needs: build-publish
+    if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both' }}
+    uses: ./github/workflows/install-lua-sdk.yml
+    with:
+      package: launchdarkly-server-sdk-redis
+      version: ${{ steps.rockspecs.outputs.server_redis_version }}


### PR DESCRIPTION
As a sanity check after publishing a LuaRock module, it'd be good to `luarocks install` it on a fresh runner to test that it actually worked. 
