### PR TITLE
ci: update install-lua-sdk workflow with unified default values

### DIFF
--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -23,24 +23,43 @@ on:
           - '5.1'
           - '5.2'
           - '5.3'
-          - '5.4'
           - 'luajit-2.0.5'
-        default: '5.4'
+        default: '5.3'
       cpp-sdk-version:
-        description: "Version of the C++ Server-side SDK to use for building and testing."
+        description: "Version of the C++ Server-side SDK."
         required: false
         type: string
         default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
+  workflow_call:
+    inputs:
+      package:
+        required: false
+        type: string
+      version:
+        required: false
+        type: string
+      lua-version:
+        required: false
+        type: string
+      cpp-sdk-version:
+        required: false
+        type: string
 
+env:
+  PACKAGE: ${{ inputs.package == null && 'launchdarkly-server-sdk' || inputs.package }}
+  VERSION: ${{ inputs.version == null && '' || inputs.version }}
+  LUA_VERSION: ${{ inputs.lua-version == null && '5.3' || inputs.lua-version }}
+  CPP_SDK_VERSION: ${{ inputs.cpp-sdk-version == null && 'launchdarkly-cpp-server-redis-source-v2.1.0' || inputs.cpp-sdk-version }}
 jobs:
   install:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Install Lua
         uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e
         with:
-          luaVersion: ${{ inputs.lua-version }}
+          luaVersion: ${{ env.LUA_VERSION }}
 
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5
@@ -55,18 +74,18 @@ jobs:
       - name: Install CPP SDK
         uses: ./.github/actions/install-cpp-sdk-redis
         with:
-          version: ${{ inputs.cpp-sdk-version }}
+          version: ${{ env.CPP_SDK_VERSION }}
           path: cpp-sdk
 
       - name: Install Package
         shell: bash
         env:
-          CPP_PATH: $GITHUB_WORKSPACE/cpp-sdk/build-dynamic/release
+          CPP_PATH: ${{ github.workspace }}/cpp-sdk/build-dynamic/release
         run: |
-          luarocks install ${{ inputs.package }} ${{ inputs.version }} \
+          luarocks install ${{ env.PACKAGE }} ${{ env.VERSION }} \
           LD_DIR=$CPP_PATH \
           LDREDIS_DIR=$CPP_PATH
 
       - name: Remove Package
         shell: bash
-        run: luarocks remove ${{ inputs.package }}
+        run: luarocks remove ${{ env.PACKAGE }}


### PR DESCRIPTION
The problem being solved here is that `workflow_dispatch`, `workflow_call`, and `schedule` events are often all useful for a single workflow. 

That is - you might want a workflow to run based on:
1. A UI interaction
2. Another workflow calling it
3. On a regular schedule

The first two, and perhaps the last, are all relevant for `install-lua-sdk`. We might have a one-off test for a particular Lua version, triggered in Github UI (1). 

We might run this after `release-please` publishes a package (2). 

And finally, we might want to ensure the package is installable every day (3).

To make this actually work, you need to ensure default values are assigned for each input. The cleanest way to do that seems to be some duplication and a "ternary" technique with environment variables.

Honestly this is pretty nasty and Github should provide a better way to do this.