### PR TITLE
ci: fix typo in manual-publish.yml

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -69,7 +69,7 @@ jobs:
     name: ${{ format('Install launchdarkly-server-sdk @ {0}', steps.rockspecs.outputs.server_version) }}
     needs: build-publish
     if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
-    uses: ./github/workflows/install-lua-sdk.yml
+    uses: ./.github/workflows/install-lua-sdk.yml
     with:
       package: launchdarkly-server-sdk
       version: ${{ steps.rockspecs.outputs.server_version }}
@@ -78,7 +78,7 @@ jobs:
     name: ${{ format('Install launchdarkly-server-sdk-redis @ {0}', steps.rockspecs.outputs.server_redis_version) }}
     needs: build-publish
     if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both' }}
-    uses: ./github/workflows/install-lua-sdk.yml
+    uses: ./.github/workflows/install-lua-sdk.yml
     with:
       package: launchdarkly-server-sdk-redis
       version: ${{ steps.rockspecs.outputs.server_redis_version }}


### PR DESCRIPTION
The reusable workflow paths used `./github` instead of `./.github`.