### PR TITLE
ci: fix invocation of ci workflow from manual-publish

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -29,7 +29,8 @@ jobs:
   rockspecs:
     uses: ./.github/workflows/rockspec-info.yml
 
-  build-publish:
+  build-publish-server:
+    if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
     needs: rockspecs
     runs-on: ubuntu-latest
 
@@ -48,42 +49,42 @@ jobs:
 
       - uses: ./.github/actions/ci
         with:
-          server-rockspec: ${{ needs.rockspecs.outputs.server }}
-          redis-rockspec: ${{ needs.rockspecs.outputs.server_redis }}
+          rockspec: ${{ needs.rockspecs.outputs.server }}
 
       - uses: ./.github/actions/publish
         name: ${{ format('Publish launchdarkly-server-sdk @ {0}', needs.rockspecs.outputs.server_version) }}
-        if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ needs.rockspecs.outputs.server }}
           skip_pack: ${{ inputs.skip_pack }}
           force: ${{ inputs.force }}
 
+  build-publish-redis:
+    if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both' }}
+    needs: rockspecs
+    runs-on: ubuntu-latest
+
+    # Needed for AWS SSM access.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
+        name: 'Get LuaRocks token'
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+
+      - uses: ./.github/actions/ci
+        with:
+          rockspec: ${{ needs.rockspecs.outputs.server_redis }}
+
       - uses: ./.github/actions/publish
         name: ${{ format('Publish launchdarkly-server-sdk-redis @ {0}', needs.rockspecs.outputs.server_redis_version) }}
-        if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both'}}
         with:
           dry_run: ${{ inputs.dry_run }}
           rockspec: ${{ needs.rockspecs.outputs.server_redis }}
           skip_pack: ${{ inputs.skip_pack }}
           force: ${{ inputs.force }}
-
-  install-server-sdk:
-    name: ${{ format('Install launchdarkly-server-sdk @ {0}', needs.rockspecs.outputs.server_version) }}
-    needs: [rockspecs, build-publish]
-    if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
-    uses: ./.github/workflows/install-lua-sdk.yml
-    with:
-      package: launchdarkly-server-sdk
-      version: ${{ needs.rockspecs.outputs.server_version }}
-
-
-  install-server-redis:
-    name: ${{ format('Install launchdarkly-server-sdk-redis @ {0}', needs.rockspecs.outputs.server_redis_version) }}
-    needs: [rockspecs, build-publish]
-    if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both' }}
-    uses: ./.github/workflows/install-lua-sdk.yml
-    with:
-      package: launchdarkly-server-sdk-redis
-      version: ${{ needs.rockspecs.outputs.server_redis_version }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -2,13 +2,13 @@ name: Publish Package
 on:
   workflow_dispatch:
     inputs:
-      rockspec:
+      package:
         type: choice
         description: 'What to publish?'
         options:
-          - server
-          - redis
-          - both
+          - '["server"]'
+          - '["redis"]'
+          - '["server","redis"]'
       dry_run:
         description: "Dry run? If checked, don't publish."
         type: boolean
@@ -26,19 +26,24 @@ on:
         default: false
 
 jobs:
-  rockspecs:
+  rockspec-info:
     uses: ./.github/workflows/rockspec-info.yml
 
-  build-publish-server:
-    if: ${{ inputs.rockspec == 'server' || inputs.rockspec == 'both' }}
-    needs: rockspecs
+  build-publish:
+    needs: rockspec-info
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: true
+      matrix:
+        package: ${{ fromJSON(inputs.package) }}
     # Needed for AWS SSM access.
     permissions:
       id-token: write
       contents: read
-
+    env:
+      PKG_VERSION: ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].version }}
+      PKG_ROCKSPEC: ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].rockspec }}
     steps:
       - uses: actions/checkout@v4
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
@@ -49,42 +54,12 @@ jobs:
 
       - uses: ./.github/actions/ci
         with:
-          rockspec: ${{ needs.rockspecs.outputs.server }}
+          rockspec: ${{ env.PKG_ROCKSPEC }}
 
       - uses: ./.github/actions/publish
-        name: ${{ format('Publish launchdarkly-server-sdk @ {0}', needs.rockspecs.outputs.server_version) }}
+        name: ${{ format('Publish {0}', env.PKG_ROCKSPEC) }}
         with:
           dry_run: ${{ inputs.dry_run }}
-          rockspec: ${{ needs.rockspecs.outputs.server }}
-          skip_pack: ${{ inputs.skip_pack }}
-          force: ${{ inputs.force }}
-
-  build-publish-redis:
-    if: ${{ inputs.rockspec == 'redis' || inputs.rockspec == 'both' }}
-    needs: rockspecs
-    runs-on: ubuntu-latest
-
-    # Needed for AWS SSM access.
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
-        name: 'Get LuaRocks token'
-        with:
-          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
-
-      - uses: ./.github/actions/ci
-        with:
-          rockspec: ${{ needs.rockspecs.outputs.server_redis }}
-
-      - uses: ./.github/actions/publish
-        name: ${{ format('Publish launchdarkly-server-sdk-redis @ {0}', needs.rockspecs.outputs.server_redis_version) }}
-        with:
-          dry_run: ${{ inputs.dry_run }}
-          rockspec: ${{ needs.rockspecs.outputs.server_redis }}
+          rockspec: ${{ env.PKG_ROCKSPEC }}
           skip_pack: ${{ inputs.skip_pack }}
           force: ${{ inputs.force }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -52,22 +52,20 @@ jobs:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
 
-      - name: Sanity check
+      - name: Get package name
+        id: pkg-info
         run: |
-            echo "Matrix value is ${{ matrix.package }}"
-            echo "brackets is ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].version }}"
-            echo "Dot literal is ${{ fromJSON(needs.rockspec-info.outputs.info).server.version }}"
-            echo "Baz is ${{ fromJSON(needs.rockspec-info.outputs.info)['server'].version }}"
-            
+            rockspec=$(echo ${{ needs.rockspec-info.outputs.info }} | jq '.${{ matrix.package }}.rockspec')
+            echo "package=$rockspec" >> $GITHUB_OUTPUT
 
       - uses: ./.github/actions/ci
         with:
-          rockspec: ${{ env.PKG_ROCKSPEC }}
+          rockspec: ${{ steps.pkg-info.outputs.package }}
 
       - uses: ./.github/actions/publish
-        name: ${{ format('Publish {0}', env.PKG_ROCKSPEC) }}
+        name: ${{ format('Publish {0}', steps.pkg-info.outputs.package) }}
         with:
           dry_run: ${{ inputs.dry_run }}
-          rockspec: ${{ env.PKG_ROCKSPEC }}
+          rockspec: ${{ steps.pkg-info.outputs.package }}
           skip_pack: ${{ inputs.skip_pack }}
           force: ${{ inputs.force }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -37,13 +37,11 @@ jobs:
       fail-fast: true
       matrix:
         package: ${{ fromJSON(inputs.package) }}
-    # Needed for AWS SSM access.
+    # Needed for AWS SSM access to get the LuaRocks token.
     permissions:
       id-token: write
       contents: read
-    env:
-      PKG_VERSION: ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].version }}
-      PKG_ROCKSPEC: ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].rockspec }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,9 +6,9 @@ on:
         type: choice
         description: 'What to publish?'
         options:
+          - '["server","redis"]'
           - '["server"]'
           - '["redis"]'
-          - '["server","redis"]'
       dry_run:
         description: "Dry run? If checked, don't publish."
         type: boolean
@@ -51,6 +51,14 @@ jobs:
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+
+      - name: Sanity check
+        run: |
+            echo "Matrix value is ${{ matrix.package }}"
+            echo "brackets is ${{ fromJSON(needs.rockspec-info.outputs.info)[matrix.package].version }}"
+            echo "Dot literal is ${{ fromJSON(needs.rockspec-info.outputs.info).server.version }}"
+            echo "Baz is ${{ fromJSON(needs.rockspec-info.outputs.info)['server'].version }}"
+            
 
       - uses: ./.github/actions/ci
         with:


### PR DESCRIPTION
In [a previous PR](https://github.com/launchdarkly/lua-server-sdk/pull/65), I refactored the `rockspec-info` into a reusable workflow. 

As part of that work, I had added a `rockspec` parameter to the CI workflow. I neglected to update `manual-publish` which calls that workflow; this PR adds the parameter.

I've also simplified the publishing step. Instead of having a bunch if `if` guards that run steps depending on if you've specified `server`, `redis`, or `both`, it's just a matrix job where the matrix is defined by the workflow input. Looks slightly ugly in the UI, but does the job.

Additionally, I think the `install` step of the workflow isn't appropriate. The idea was to publish the package and then subsequently install it as a sanity check, but I think that could be quite flaky if there are any delays. I'd rather it be a periodic test that happens daily or something. 

- [x] Tested with `redis` package
- [x] Tested with `server` package
- [x] Tested with both
