### PR TITLE
ci: publish packages with release-please

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.2
         name: 'Get LuaRocks token'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,44 +7,87 @@ on:
       - main
 
 jobs:
-  release-package:
+  rockspec-info:
+    uses: ./.github/workflows/rockspec-info.yml
+
+  release-please:
     runs-on: ubuntu-latest
 
     permissions:
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
 
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr_branch_name: ${{ steps.release.outputs.prs_created == 'true' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  update-release-pr:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
-
       - name: Update launchdarkly-server-sdk rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
           package: launchdarkly-server-sdk
-          branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          branch: ${{ needs.release-please.outputs.pr_branch_name }}
 
       - name: Update launchdarkly-server-sdk-redis rockspec
         uses: ./.github/actions/update-versions
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
           package: launchdarkly-server-sdk-redis
-          branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          branch: ${{ needs.release-please.outputs.pr_branch_name }}
 
-      - name: Build and Test
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        uses: ./.github/actions/ci
-
+  publish-docs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Build documentation
-        if: ${{ steps.release.outputs.release_created == 'true' }}
         uses: ./.github/actions/build-docs
 
-      - uses: ./.github/actions/publish-docs
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+      - name: Publish docs
+        uses: ./.github/actions/publish-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-server:
+    needs: [release-please, rockspec-info]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.2
+      name: 'Get LuaRocks token'
+      with:
+        aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+        ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+    - uses: ./.github/actions/publish
+      name: Publish server package
+      with:
+        dry_run: 'false'
+        rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).server }}
+
+  publish-redis:
+    needs: [ publish-server, rockspec-info ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.2
+        name: 'Get LuaRocks token'
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+      - uses: ./.github/actions/publish
+        name: Publish redis package
+        with:
+          dry_run: 'false'
+          rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).redis }}


### PR DESCRIPTION
Updates `release-please` workflow to actually perform a release, in a similar manner to recently merged `manual-publish` workflow.

-------------------------

There's one main difference: in the manual workflow, it uses a matrix to publish both packages. Here, it publishes the server first, and the redis integration next.

I don't really know which technique will be better for this repo so I'm splitting the difference. 

Sequential avoids a race condition where Redis integration version X depends on server Y (but it's not yet published), and also has `fail-fast: true` so if the server doesn't publish, the redis integration won't publish. 

It's also more amenable to making this be a true multi-package repo in the future (right now both packages are always published for any releasable unit.)

Matrix is nice because it reduces boilerplate. 