### PR TITLE
fix: add hello-haproxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'cw/**' ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,11 @@ jobs:
         run: |
           docker build -t launchdarkly:hello-haproxy -f ./examples/hello-haproxy/Dockerfile .
       - name: Run hello-haproxy container in background
-        # The sleep is to give haproxy some time to start-up.
         run: |
           docker run -dit --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:hello-haproxy
-          sleep 5
       - name: Evaluate feature flag
         run: |
-          curl -s -v http://localhost:8123 | tee response.txt
+          curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
           grep -F "Feature flag is false for this user" response.txt || (echo "Expected false evaluation!" && exit 1)
       - name: Stop hello-haproxy container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,23 @@ jobs:
         with:
           lua-version: ${{ matrix.version }}
           rockspec: ${{ matrix.package }}
+
+
+  hello-haproxy:
+    runs-on: ubuntu-latest
+    env:
+      LD_SDK_KEY: "foo"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build hello-haproxy image
+        run: |
+          docker build -t launchdarkly:hello-haproxy -f ./examples/hello-haproxy/Dockerfile .
+      - name: Run hello-haproxy container in background
+        run: |
+          docker run -dit --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:hello-haproxy
+      - name: Evaluate feature flag
+        run: |
+          curl -s http://localhost:8123
+      - name: Stop hello-haproxy container
+        run: |
+          docker stop hello-haproxy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           docker build -t launchdarkly:hello-haproxy -f ./examples/hello-haproxy/Dockerfile .
       - name: Run hello-haproxy container in background
+        # The sleep is to give haproxy some time to start-up.
         run: |
           docker run -dit --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:hello-haproxy
           sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
           sleep 5
       - name: Evaluate feature flag
         run: |
-          curl -s -v http://localhost:8123
+          curl -s -v http://localhost:8123 | tee response.txt
+          grep -F "Feature flag is false for this user" response.txt || (echo "Expected HTTP response from haproxy" && exit 1)
       - name: Stop hello-haproxy container
         run: |
           docker stop hello-haproxy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,10 @@ jobs:
       - name: Run hello-haproxy container in background
         run: |
           docker run -dit --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:hello-haproxy
+          sleep 5
       - name: Evaluate feature flag
         run: |
-          curl -s http://localhost:8123
+          curl -s -v http://localhost:8123
       - name: Stop hello-haproxy container
         run: |
           docker stop hello-haproxy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ main, 'cw/**' ]
+    branches: [ main ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Evaluate feature flag
         run: |
           curl -s -v http://localhost:8123 | tee response.txt
-          grep -F "Feature flag is false for this user" response.txt || (echo "Expected HTTP response from haproxy" && exit 1)
+          grep -F "Feature flag is false for this user" response.txt || (echo "Expected false evaluation!" && exit 1)
       - name: Stop hello-haproxy container
         run: |
           docker stop hello-haproxy

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Getting started
 Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/server-side/lua#getting-started) for instructions on 
 getting started with using the SDK.
 
-Runnable examples in this repo are available:
+The following examples are available in addition to the usage guide linked above:
+
 
 | Example                                         | Purpose                                                                                       |
 |-------------------------------------------------|-----------------------------------------------------------------------------------------------|
@@ -57,18 +58,20 @@ Runnable examples in this repo are available:
 | [hello-haproxy](./examples/hello-haproxy)       | Demonstrates usage of the Lua SDK as a [HAproxy](https://www.haproxy.org/) module via Docker. |
 
 
+Before you start using the SDK, you'll need to install it.
+
 There are two paths to installing the SDK. In both cases, you must first install the native 
 [LaunchDarkly C++ Server-side SDK](https://github.com/launchdarkly/cpp-sdks).
 
 You may build the C++ SDK from source using [CMake](https://cmake.org/), or obtain pre-built artifacts from the 
 [releases page](https://github.com/launchdarkly/cpp-sdks/releases?q=%22launchdarkly-cpp-server%22). Ensure you install
-the correct variant (with or without Redis support) as necessary.
+the correct variant (with or without Redis support) as defined by your requirements.
 
 Please note that the Lua SDK uses the C++ server-side SDK's C bindings, so if you're using prebuilt artifacts
 then only a C99 compiler is necessary. See the [Build Requirements](https://github.com/launchdarkly/cpp-sdks#build-requirements).
 
 
-Then, install the [LuaRocks](https://github.com/luarocks/luarocks/wiki/Download) package manager.
+Once the C++ SDK is available, install the [LuaRocks](https://github.com/luarocks/luarocks/wiki/Download) package manager.
 
 ### Install via `luarocks install`
 
@@ -89,7 +92,7 @@ LDREDIS_DIR=./path-to-cpp-sdk-with-redis-support-installation
 
 ### Install via `luarocks make`
 
-If you don't want to install from LuaRocks, it's possible to compile the modules locally using `luarocks make`.
+If you don't want to install from LuaRocks, it's possible to compile the modules locally in this git repo by using `luarocks make`.
 
 **Install the base SDK only**
 ```bash
@@ -111,7 +114,7 @@ Read our [documentation](https://docs.launchdarkly.com) for in-depth instruction
 Testing
 -------
 
-We run integration tests for all our SDKs using a centralized test harness. This approach gives us the ability to test for consistency across SDKs, as well as test networking behavior in a long-running application. These tests cover each method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all behave correctly.
+We run integration tests for all our SDKs using a centralized test harness. This approach gives us the ability to test for consistency across SDKs. These tests cover each method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all behave correctly.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Getting started
 Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/server-side/lua#getting-started) for instructions on 
 getting started with using the SDK.
 
+Runnable examples in this repo are available:
+
+| Example                                         | Purpose                                                                                       |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| [hello-lua-server](./examples/hello-lua-server) | Demonstrates basic example of Lua SDK usage from the command line.                            |
+| [hello-haproxy](./examples/hello-haproxy)       | Demonstrates usage of the Lua SDK as a [HAproxy](https://www.haproxy.org/) module via Docker. |
+
+
 There are two paths to installing the SDK. In both cases, you must first install the native 
 [LaunchDarkly C++ Server-side SDK](https://github.com/launchdarkly/cpp-sdks).
 

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -21,8 +21,19 @@ RUN luarocks make launchdarkly-server-sdk-2.0.2-0.rockspec LD_DIR=./cpp-sdk/buil
 COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ./examples/hello-haproxy/service.lua /service.lua
 
-# The boost we install from the ppa is named differently than the one the SDK expects to link against. This wouldn't be necessary
-# if we built the SDK from source, but that would take a while and this is meant to run often in CI.
+# The strategy for this Docker example is to download the C++ SDK release artifacts and use those instead of compiling
+# from source. This is for example/CI purposes only; generally it's better to build from source to ensure all libraries
+# are compatible.
+#
+# Since we require a newer version of boost than is available in Ubuntu 22.04, we grab it from a PPA (mhier/libboost-latest).
+#
+# The SDK dynamic libs expect the boost libs to follow a specific naming convention, which isn't what
+# the libraries from the PPA follow ('-mt' suffix is added to indicate the libraries are built with multithreading support enabled.)
+#
+# It's not 100% clear if these libraries are multithread enabled (build logs in the PPA seem to indicate it),
+# but even so, the C++ SDK is single-threaded.
+#
+# To workaround, add symlinks with the expected names.
 RUN cd /usr/lib/x86_64-linux-gnu && \
     ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
     ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -9,7 +9,6 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
      apt-get update && \
      apt-get install -y boost1.81
 
-
 RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.1/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
     mkdir ./cpp-sdk && \
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
@@ -22,6 +21,8 @@ RUN luarocks make launchdarkly-server-sdk-2.0.2-0.rockspec LD_DIR=./cpp-sdk/buil
 COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ./examples/hello-haproxy/service.lua /service.lua
 
+# The boost we install from the ppa is named differently than the one the SDK expects to link against. This wouldn't be necessary
+# if we built the SDK from source, but that would take a while and this is meant to run often in CI.
 RUN cd /usr/lib/x86_64-linux-gnu && \
     ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
     ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    curl luarocks lua5.3 lua5.3-dev \
+    haproxy apt-transport-https ca-certificates \
+    software-properties-common
+
+RUN add-apt-repository ppa:mhier/libboost-latest && \
+     apt-get update && \
+     apt-get install -y boost1.81
+
+
+RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.1/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
+    mkdir ./cpp-sdk && \
+    unzip /tmp/sdk.zip -d ./cpp-sdk && \
+    rm /tmp/sdk.zip
+
+COPY . .
+
+RUN luarocks make launchdarkly-server-sdk-2.0.2-0.rockspec LD_DIR=./cpp-sdk/build-dynamic/release
+
+COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
+COPY ./examples/hello-haproxy/service.lua /service.lua
+
+RUN cd /usr/lib/x86_64-linux-gnu && \
+    ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
+    ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0
+
+CMD  haproxy -d -f /etc/haproxy/haproxy.cfg

--- a/examples/hello-haproxy/README.md
+++ b/examples/hello-haproxy/README.md
@@ -1,0 +1,16 @@
+# LaunchDarkly Lua server-side SDK HAProxy example
+
+We've built a minimal dockerized example of using the Lua SDK with [HAProxy](https://www.haproxy.org/). For more comprehensive instructions, you can visit the [Using the Lua SDK with HAProxy guide](https://docs.launchdarkly.com/guides/sdk/haproxy) or the [Lua reference guide](https://docs.launchdarkly.com/sdk/server-side/lua).
+
+## Build instructions
+
+1. On the command line from the root of the repo, build the image from this directory with `docker build -t hello-haproxy -f ./examples/hello-haproxy/Dockerfile .`.
+2. Run the demo with:  
+    ```
+    docker run -it --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="your-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-haproxy```
+    ```
+3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LD_FLAG_KEY` should be a boolean-type flag in your environment.
+4. Open `localhost:8123` in your browser. Toggle the flag on to see a change in the page (refresh the page.)
+
+You should receive the message: 
+> Feature flag is <true/false> for this user.

--- a/examples/hello-haproxy/haproxy.cfg
+++ b/examples/hello-haproxy/haproxy.cfg
@@ -1,0 +1,15 @@
+global
+   lua-load /service.lua
+
+defaults
+    mode http
+    timeout connect 10s
+    timeout client 30s
+    timeout server 30s
+
+frontend proxy
+    bind 0.0.0.0:8123
+    use_backend default_backend
+
+backend default_backend
+    http-request use-service lua.launchdarkly

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -45,6 +45,6 @@ core.register_service("launchdarkly", "http", function(applet)
     if client:boolVariation(user, get_key_from_env_or("FLAG_KEY", YOUR_FEATURE_KEY), false) then
         applet:send("<p>Feature flag is true for this user</p>")
     else
-        applet:send("<p>Feature flag is false for this user</p>")
+        applet:send("<p>Feature flag is blah blah for this user</p>")
     end
 end)

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -1,0 +1,46 @@
+print "loaded"
+
+local os = require("os")
+local ld = require("launchdarkly_server_sdk")
+
+
+-- Set YOUR_SDK_KEY to your LaunchDarkly SDK key.
+local YOUR_SDK_KEY = ""
+
+-- Set YOUR_FEATURE_KEY to the feature flag key you want to evaluate.
+local YOUR_FEATURE_KEY = "my-boolean-flag"
+
+
+-- Allows the LaunchDarkly SDK key to be specified as an environment variable (LD_SDK_KEY)
+-- or locally in this example code (YOUR_SDK_KEY).
+function get_key_from_env_or(name, existing_key)
+    if existing_key ~= "" then
+        return existing_key
+    end
+
+    local env_key = os.getenv("LD_" .. name)
+    if env_key ~= "" then
+        return env_key
+    end
+
+    error("No " .. name .. " specified (use LD_" .. name .. " environment variable or set local YOUR_" .. name .. ")")
+end
+
+local client = ld.clientInit(get_key_from_env_or("SDK_KEY", YOUR_SDK_KEY), 1000, config)
+
+core.register_service("launchdarkly", "http", function(applet)
+    applet:start_response()
+
+    local user = ld.makeContext({
+        user =  {
+            key = "example-user-key",
+            name = "Sandy"
+        }
+    })
+
+    if client:boolVariation(user, get_key_from_env_or("FLAG_KEY", YOUR_FEATURE_KEY), false) then
+        applet:send("<p>Feature flag is true for this user</p>")
+    else
+        applet:send("<p>Feature flag is false for this user</p>")
+    end
+end)

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -45,6 +45,6 @@ core.register_service("launchdarkly", "http", function(applet)
     if client:boolVariation(user, get_key_from_env_or("FLAG_KEY", YOUR_FEATURE_KEY), false) then
         applet:send("<p>Feature flag is true for this user</p>")
     else
-        applet:send("<p>Feature flag is blah blah for this user</p>")
+        applet:send("<p>Feature flag is false for this user</p>")
     end
 end)

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -14,18 +14,22 @@ local YOUR_FEATURE_KEY = "my-boolean-flag"
 -- Allows the LaunchDarkly SDK key to be specified as an environment variable (LD_SDK_KEY)
 -- or locally in this example code (YOUR_SDK_KEY).
 function get_key_from_env_or(name, existing_key)
-    if existing_key ~= "" then
+    if existing_key ~= nil and existing_key ~= "" then
+        core.Debug("Using LaunchDarkly SDK key from service.lua file")
         return existing_key
     end
 
     local env_key = os.getenv("LD_" .. name)
-    if env_key ~= "" then
+    if env_key ~= nil and env_key ~= "" then
+        core.Debug("Using LaunchDarkly SDK key from LD_" .. name .. " environment variable")
         return env_key
     end
 
-    error("No " .. name .. " specified (use LD_" .. name .. " environment variable or set local YOUR_" .. name .. ")")
+    core.log(core.crit, "LaunchDarkly SDK key not provided! SDK won't be initialized.")
+    return ""
 end
 
+local config = {}
 local client = ld.clientInit(get_key_from_env_or("SDK_KEY", YOUR_SDK_KEY), 1000, config)
 
 core.register_service("launchdarkly", "http", function(applet)


### PR DESCRIPTION
Incorporates the [`hello-haproxy`](https://github.com/launchdarkly/hello-haproxy) example directly into the repo so it can be continually tested and kept up-to-date.

This is `fix` because:
- Should have been in the repo in the first place :) 
- Test out `release-please`, but..
- ..doesn't generate a new minor version