### PR TITLE
ci: fix release-please permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,15 +6,17 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write # Needed to create the release PR
+  contents: write # Needed to generate the release
+
+
 jobs:
   rockspec-info:
     uses: ./.github/workflows/rockspec-info.yml
 
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Needed to create the release PR
-      contents: write # Needed to generate the release
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   update-release-pr:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}
 
   update-release-pr:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,10 +12,9 @@ jobs:
 
   release-please:
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write # Contents and pull-requests are for release-please to make releases.
-      pull-requests: write
+      pull-requests: write # Needed to create the release PR
+      contents: write # Needed to generate the release
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -46,6 +45,8 @@ jobs:
           branch: ${{ needs.release-please.outputs.pr_branch_name }}
 
   publish-docs:
+    permissions:
+      contents: write # Needed to publish to Github Pages
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
@@ -60,6 +61,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-server:
+    permissions: # Needed for access to the LuaRocks token
+      id-token: write
+      contents: read
     needs: [release-please, rockspec-info]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
@@ -77,6 +81,9 @@ jobs:
         rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).server }}
 
   publish-redis:
+    permissions: # Needed for access to the LuaRocks token
+      id-token: write
+      contents: read
     needs: [ publish-server, rockspec-info ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write # Needed to create the release PR
-  contents: write # Needed to generate the release
-
 
 jobs:
   rockspec-info:
@@ -17,6 +13,9 @@ jobs:
 
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Needed to create the release PR
+      contents: write # Needed to generate the release
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -25,6 +24,8 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   update-release-pr:
     needs: release-please


### PR DESCRIPTION
This grants the release-please workflow the correct permissions (hopefully) for executing the publish docs / packages steps. 

More critically, it sets the `target-branch` on the `release-please` action, which is necessary for the workflow to succeed when run from a workflow_dispatch call. 