### PR TITLE
ci: use release-please fork with error logging

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,7 @@
 name: Run Release Please
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,7 @@ jobs:
 
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Needed to create the release PR
-      contents: write # Needed to generate the release
+
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,6 @@
 name: Run Release Please
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,6 @@
 name: Run Release Please
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -22,7 +21,7 @@ jobs:
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr_branch_name: ${{ steps.release.outputs.prs_created == 'true' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: cwaldren-ld/release-please-action@abc94317b0567221f719cd278b2a2a597a2069fe
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
 
+permissions: write-all
 
 jobs:
   rockspec-info:


### PR DESCRIPTION
This is purely for testing out release-please, and should be reverted.