### PR TITLE
ci: remove rockspec-info.yml from release-please extra-files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,8 +8,7 @@ on:
 
 
 jobs:
-  rockspec-info:
-    uses: ./.github/workflows/rockspec-info.yml
+
 
   release-please:
     runs-on: ubuntu-latest
@@ -28,12 +27,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
 
+  rockspec-info:
+    needs: release-please
+    uses: ./.github/workflows/rockspec-info.yml
+
   update-release-pr:
     needs: release-please
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     runs-on: ubuntu-latest
-    permissions:
-      workflows: write
     steps:
       - uses: actions/checkout@v4
       - name: Update launchdarkly-server-sdk rockspec

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,97 @@ on:
     branches:
       - main
 
+
 jobs:
+  rockspec-info:
+    uses: ./.github/workflows/rockspec-info.yml
+
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Needed to create the release PR
+      contents: write # Needed to generate the release
+
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr_branch_name: ${{ steps.release.outputs.prs_created == 'true' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
-      - uses: cwaldren-ld/release-please-action@ab8a11107d3502767d424835d5084ab324b1095c
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
+
+  update-release-pr:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update launchdarkly-server-sdk rockspec
+        uses: ./.github/actions/update-versions
+        with:
+          package: launchdarkly-server-sdk
+          branch: ${{ needs.release-please.outputs.pr_branch_name }}
+
+      - name: Update launchdarkly-server-sdk-redis rockspec
+        uses: ./.github/actions/update-versions
+        with:
+          package: launchdarkly-server-sdk-redis
+          branch: ${{ needs.release-please.outputs.pr_branch_name }}
+
+  publish-docs:
+    permissions:
+      contents: write # Needed to publish to Github Pages
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
+
+      - name: Publish docs
+        uses: ./.github/actions/publish-docs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-server:
+    permissions: # Needed for access to the LuaRocks token
+      id-token: write
+      contents: read
+    needs: [release-please, rockspec-info]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.2
+        name: 'Get LuaRocks token'
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+      - uses: ./.github/actions/publish
+        name: Publish server package
+        with:
+          dry_run: 'false'
+          rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).server }}
+
+  publish-redis:
+    permissions: # Needed for access to the LuaRocks token
+      id-token: write
+      contents: read
+    needs: [ publish-server, rockspec-info ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.2
+        name: 'Get LuaRocks token'
+        with:
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+      - uses: ./.github/actions/publish
+        name: Publish redis package
+        with:
+          dry_run: 'false'
+          rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).redis }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,5 +10,5 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: cwaldren-ld/release-please-action@5ef0c65ec53b27564666fc9a4b3d0d76dcc0c48c
+      - uses: cwaldren-ld/release-please-action@eac2b02ccd6fb51842de42218cd3f7568421d2db
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,5 +12,3 @@ jobs:
     steps:
       - uses: cwaldren-ld/release-please-action@c20bc7716919838e71934160b59925db0b3e59af
         id: release
-        with:
-          token: ${{ github.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,3 +14,4 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,5 +10,5 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: cwaldren-ld/release-please-action@eac2b02ccd6fb51842de42218cd3f7568421d2db
+      - uses: cwaldren-ld/release-please-action@ab8a11107d3502767d424835d5084ab324b1095c
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,10 +6,7 @@ on:
     branches:
       - main
 
-
 jobs:
-
-
   release-please:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: cwaldren-ld/release-please-action@c20bc7716919838e71934160b59925db0b3e59af
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: cwaldren-ld/release-please-action@ab8a11107d3502767d424835d5084ab324b1095c
         id: release
+        with:
+          token: bogus

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,5 +10,5 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: cwaldren-ld/release-please-action@c20bc7716919838e71934160b59925db0b3e59af
+      - uses: cwaldren-ld/release-please-action@5ef0c65ec53b27564666fc9a4b3d0d76dcc0c48c
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: cwaldren-ld/release-please-action@ab8a11107d3502767d424835d5084ab324b1095c
         id: release
         with:
-          token: bogus
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      workflows: write
     steps:
       - uses: actions/checkout@v4
       - name: Update launchdarkly-server-sdk rockspec

--- a/.github/workflows/rockspec-info.yml
+++ b/.github/workflows/rockspec-info.yml
@@ -7,8 +7,8 @@ on:
         value: ${{ jobs.rockspec-info.outputs.info }}
 
 env:
-  LUA_SERVER_VERSION: "2.0.2"  # {x-release-please-version}
-  LUA_SERVER_REDIS_VERSION: "2.0.2" # {x-release-please-version}
+  LUA_SERVER_VERSION: "2.0.2"
+  LUA_SERVER_REDIS_VERSION: "2.0.2"
 
 
 jobs:

--- a/.github/workflows/rockspec-info.yml
+++ b/.github/workflows/rockspec-info.yml
@@ -6,11 +6,6 @@ on:
         description: "JSON object with rockspec info"
         value: ${{ jobs.rockspec-info.outputs.info }}
 
-env:
-  LUA_SERVER_VERSION: "2.0.2"
-  LUA_SERVER_REDIS_VERSION: "2.0.2"
-
-
 jobs:
   rockspec-info:
     runs-on: ubuntu-latest
@@ -18,12 +13,17 @@ jobs:
       info: ${{ steps.pkg-info.outputs.info }}
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch release please manifest
+        id: manifest
+        run: |
+            version=$(jq '."."' < .release-please-manifest.json)
+            echo "version=$version" >> $GITHUB_OUTPUT
       - name: Construct rockspec package names
         id: pkg-info
         run: |
           echo 'info<<EOF' >> $GITHUB_OUTPUT
           echo '"{' >> $GITHUB_OUTPUT
-          echo '\"server\":{\"version\":\"${{ env.LUA_SERVER_VERSION}}\",\"rockspec\":\"launchdarkly-server-sdk-${{ env.LUA_SERVER_VERSION }}-0.rockspec\"},' >> $GITHUB_OUTPUT
-          echo '\"redis\":{\"version\":\"${{ env.LUA_SERVER_REDIS_VERSION}}\",\"rockspec\":\"launchdarkly-server-sdk-redis-${{ env.LUA_SERVER_REDIS_VERSION }}-0.rockspec\"}' >> $GITHUB_OUTPUT
+          echo '\"server\":{\"version\":\"${{ steps.manifest.outputs.version }}\",\"rockspec\":\"launchdarkly-server-sdk-${{ steps.manifest.outputs.version }}-0.rockspec\"},' >> $GITHUB_OUTPUT
+          echo '\"redis\":{\"version\":\"${{ steps.manifest.outputs.version }}\",\"rockspec\":\"launchdarkly-server-sdk-redis-${{ steps.manifest.outputs.version }}-0.rockspec\"}' >> $GITHUB_OUTPUT
           echo '}"' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "versioning": "default",
       "extra-files": [
         "launchdarkly-server-sdk.c",
+        ".github/workflows/rockspec-info.yml",
         "README.md",
         "scripts/update-versions.sh",
         "scripts/compile.sh"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,14 +3,7 @@
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "versioning": "default",
-      "extra-files": [
-        "launchdarkly-server-sdk.c",
-        ".github/workflows/rockspec-info.yml",
-        "README.md",
-        "scripts/update-versions.sh",
-        "scripts/compile.sh"
-      ]
+      "versioning": "default"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,13 @@
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "versioning": "default"
+      "versioning": "default",
+      "extra-files": [
+        "launchdarkly-server-sdk.c",
+        "README.md",
+        "scripts/update-versions.sh",
+        "scripts/compile.sh"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "versioning": "default",
       "extra-files": [
         "launchdarkly-server-sdk.c",
-        ".github/workflows/rockspec-info.yml",
         "README.md",
         "scripts/update-versions.sh",
         "scripts/compile.sh"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -90,10 +90,6 @@ for file in "$input_rockspec"-*.rockspec; do
     echo "Updated README.md code example"
     rm -f README.md.bak
 
-    sed -i.bak "s/LUA_SERVER_VERSION: \".*\"/LUA_SERVER_VERSION: \"$input_version\"/" .github/workflows/rockspec-info.yml
-    sed -i.bak "s/LUA_SERVER_REDIS_VERSION: \".*\"/LUA_SERVER_REDIS_VERSION: \"$input_version\"/" .github/workflows/rockspec-info.yml
-    echo "Updated versions in rockspec-info.yml"
-    rm -rf .github/workflows/rockspec-info.yml.bak
 
     if [ "$(git status --porcelain | wc -l)" -gt 0 ]; then
       if [ -n "$git_username" ]; then
@@ -104,7 +100,6 @@ for file in "$input_rockspec"-*.rockspec; do
       fi
       git add "$new_file_name"
       git add README.md
-      git add .github/workflows/rockspec-info.yml
       if [ $autocommit ]; then
         git commit -m "chore: bump $input_rockspec version from $semver to $input_version"
         git push

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -90,6 +90,10 @@ for file in "$input_rockspec"-*.rockspec; do
     echo "Updated README.md code example"
     rm -f README.md.bak
 
+    sed -i.bak "s/LUA_SERVER_VERSION: \".*\"/LUA_SERVER_VERSION: \"$input_version\"/" .github/workflows/rockspec-info.yml
+    sed -i.bak "s/LUA_SERVER_REDIS_VERSION: \".*\"/LUA_SERVER_REDIS_VERSION: \"$input_version\"/" .github/workflows/rockspec-info.yml
+    echo "Updated versions in rockspec-info.yml"
+    rm -rf .github/workflows/rockspec-info.yml.bak
 
     if [ "$(git status --porcelain | wc -l)" -gt 0 ]; then
       if [ -n "$git_username" ]; then
@@ -100,6 +104,7 @@ for file in "$input_rockspec"-*.rockspec; do
       fi
       git add "$new_file_name"
       git add README.md
+      git add .github/workflows/rockspec-info.yml
       if [ $autocommit ]; then
         git commit -m "chore: bump $input_rockspec version from $semver to $input_version"
         git push


### PR DESCRIPTION
This should _actually_ fix release please!

The root cause of the errors seems to have been that you cannot update a Github workflow file using `extra-files` in a release please manifest. This is disallowed by the Github API. 

I've refactored the `rockspec-info` workflow to not need to be updated at all. Instead, it grabs the current version from the existing `.release-please-manifest`. I should have done this in the first place as it's much cleaner.