### PR TITLE
fix: add missing ci step to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+      - uses: ./.github/actions/ci
+        with:
+          rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).server }}
       - uses: ./.github/actions/publish
         name: Publish server package
         with:
@@ -95,6 +98,9 @@ jobs:
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/luarocks/token = LUAROCKS_API_TOKEN'
+      - uses: ./.github/actions/ci
+        with:
+          rockspec: ${{ fromJSON(needs.rockspec-info.outputs.info).redis }}
       - uses: ./.github/actions/publish
         name: Publish redis package
         with:

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # {{ x-release-please-start-version }}
-ENV version=2.0.3
+ARG VERSION=2.0.3
 # {{ x-release-please-end }}
 
 RUN apt-get update && apt-get install -y \
@@ -19,11 +19,12 @@ RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly
     rm /tmp/sdk.zip
 
 COPY . .
-
-RUN luarocks make launchdarkly-server-sdk-$version-0.rockspec LD_DIR=./cpp-sdk/build-dynamic/release
-
 COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ./examples/hello-haproxy/service.lua /service.lua
+
+RUN luarocks make launchdarkly-server-sdk-"${VERSION}"-0.rockspec LD_DIR=./cpp-sdk/build-dynamic/release
+
+
 
 # The strategy for this Docker example is to download the C++ SDK release artifacts and use those instead of compiling
 # from source. This is for example/CI purposes only; generally it's better to build from source to ensure all libraries

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:22.04
 
+# {{ x-release-please-start-version }}
+ENV version=2.0.3
+# {{ x-release-please-end }}
+
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \
     haproxy apt-transport-https ca-certificates \
@@ -14,10 +18,9 @@ RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
     rm /tmp/sdk.zip
 
-COPY launchdarkly-server-sdk-2*.rockspec .
-COPY launchdarkly-server-sdk.c .
+COPY . .
 
-RUN luarocks make LD_DIR=./cpp-sdk/build-dynamic/release
+RUN luarocks make launchdarkly-server-sdk-$version-0.rockspec LD_DIR=./cpp-sdk/build-dynamic/release
 
 COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ./examples/hello-haproxy/service.lua /service.lua

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -14,9 +14,10 @@ RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
     rm /tmp/sdk.zip
 
-COPY . .
+COPY launchdarkly-server-sdk-2*.rockspec .
+COPY launchdarkly-server-sdk.c .
 
-RUN luarocks make launchdarkly-server-sdk-2.0.2-0.rockspec LD_DIR=./cpp-sdk/build-dynamic/release
+RUN luarocks make LD_DIR=./cpp-sdk/build-dynamic/release
 
 COPY ./examples/hello-haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY ./examples/hello-haproxy/service.lua /service.lua

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
         "launchdarkly-server-sdk.c",
         "README.md",
         "scripts/update-versions.sh",
-        "scripts/compile.sh"
+        "scripts/compile.sh",
+        "examples/hello-haproxy/Dockerfile"
       ]
     }
   }


### PR DESCRIPTION
The release-please workflow's `publish` action will fail because it needs Lua installed (which is done in the `ci` action.)

It might be ideal to have that setup take place independently of `ci` - but here I'm fixing it by adding in `ci` (just as is done in the manual publish workflow.) This is probably a good practice anyways since we don't want to be release code that fails unit tests.

Additionally, the `hello-haproxy` example had a hardcoded rockspec version. This updates it so it can float. Having version numbers in filenames is really the root of a lot of pain here. 