### PR TITLE
fix: rockspec info JSON was generated incorrectly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          data=$(echo ${{ needs.rockspec-info.outputs.info }} | jq -c 'to_entries | map(.value.rockspec)')
+          data=$(echo '${{ needs.rockspec-info.outputs.info }}' | jq -c 'to_entries | map(.value.rockspec)')
           echo "matrix=$data" >> $GITHUB_OUTPUT
 
   linux-build:

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get package name
         id: pkg-info
         run: |
-            rockspec=$(echo '${{ needs.rockspec-info.outputs.info }}' | jq '.${{ matrix.package }}.rockspec')
+            rockspec=$(echo '${{ needs.rockspec-info.outputs.info }}' | jq -r '.${{ matrix.package }}.rockspec')
             echo "package=$rockspec" >> $GITHUB_OUTPUT
 
       - uses: ./.github/actions/ci

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get package name
         id: pkg-info
         run: |
-            rockspec=$(echo ${{ needs.rockspec-info.outputs.info }} | jq '.${{ matrix.package }}.rockspec')
+            rockspec=$(echo '${{ needs.rockspec-info.outputs.info }}' | jq '.${{ matrix.package }}.rockspec')
             echo "package=$rockspec" >> $GITHUB_OUTPUT
 
       - uses: ./.github/actions/ci

--- a/.github/workflows/rockspec-info.yml
+++ b/.github/workflows/rockspec-info.yml
@@ -20,10 +20,11 @@ jobs:
             echo "version=$version" >> $GITHUB_OUTPUT
       - name: Construct rockspec package names
         id: pkg-info
+        env:
+          V: ${{ steps.manifest.outputs.version }}
         run: |
-          echo 'info<<EOF' >> $GITHUB_OUTPUT
-          echo '"{' >> $GITHUB_OUTPUT
-          echo '\"server\":{\"version\":\"${{ steps.manifest.outputs.version }}\",\"rockspec\":\"launchdarkly-server-sdk-${{ steps.manifest.outputs.version }}-0.rockspec\"},' >> $GITHUB_OUTPUT
-          echo '\"redis\":{\"version\":\"${{ steps.manifest.outputs.version }}\",\"rockspec\":\"launchdarkly-server-sdk-redis-${{ steps.manifest.outputs.version }}-0.rockspec\"}' >> $GITHUB_OUTPUT
-          echo '}"' >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          json=$(echo 'null' | jq -c '{
+          "server":{"version":"${{ env.V }}","rockspec":"launchdarkly-server-sdk-${{ env.V }}-0.rockspec"},
+          "redis":{"version":"${{ env.V }}","rockspec":"launchdarkly-server-sdk-redis-${{ env.V }}-0.rockspec"}
+          }')
+          echo "info=$json" >> $GITHUB_OUTPUT 


### PR DESCRIPTION
In the `rockspec-info` workflow, we create a JSON object that contains rockspec versions/filenames that other steps can use. 

The JSON string wasn't outputted correctly, preventing `fromJSON(info)` from returning an object with accessible properties. 

This commit both fixes it and makes it easier to read by utilizing `jq` to create the JSON string. 

I've tested the `manual-publish` and `release-please` workflows on this PR (although can't test the full release flow until this is merged.)