### PR TITLE
ci: bump cpp SDK to bring in user-agent fix

### DIFF
--- a/.github/actions/install-cpp-sdk-redis/action.yml
+++ b/.github/actions/install-cpp-sdk-redis/action.yml
@@ -4,7 +4,7 @@ inputs:
     version:
         required: true
         description: "Version of the C++ SDK with Redis Source."
-        default: "launchdarkly-cpp-server-redis-source-v2.1.0"
+        default: "launchdarkly-cpp-server-redis-source-v2.1.2"
     path:
       description: "Where to download the SDK."
       default: "cpp-sdk"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                            | Notes                                      |
 |--------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.3.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.3.0)              | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.1.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.0) | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.3.2](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.3.2)              | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.1.2](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.2) | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -13,7 +13,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
      apt-get update && \
      apt-get install -y boost1.81
 
-RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.1/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
+RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.2/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
     mkdir ./cpp-sdk && \
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
     rm /tmp/sdk.zip

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -15,7 +15,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
 
 
 RUN mkdir cpp-sdk-libs
-RUN git clone --branch launchdarkly-cpp-server-v3.3.1 https://github.com/launchdarkly/cpp-sdks.git && \
+RUN git clone --branch launchdarkly-cpp-server-v3.3.2 https://github.com/launchdarkly/cpp-sdks.git && \
     cd cpp-sdks && \
     mkdir build-dynamic && \
     cd build-dynamic && \


### PR DESCRIPTION
CPP server had a bug where it was sending a `CPPClient` as its user-agent. This bumps the default version used in Lua's CI and examples.

I've also updated the README minimum versions since this bug affects usage statistics. 