### PR TITLE
chore: add examples/hello-nginx/Dockerfile to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
         "README.md",
         "scripts/update-versions.sh",
         "scripts/compile.sh",
-        "examples/hello-haproxy/Dockerfile"
+        "examples/hello-haproxy/Dockerfile",
+        "examples/hello-nginx/Dockerfile"
       ]
     }
   }


### PR DESCRIPTION
Forgot to add `hello-nginx` to release-please config, so it wasn't updated in the latest release PR.