### PR TITLE
ci: bump C++ SDK to 3.3.3, C++ Redis to 2.1.3

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -8,7 +8,7 @@ inputs:
   cpp-sdk-version:
     description: 'Version of the C++ Server-side SDK to use for building and testing.'
     required: false
-    default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
+    default: 'launchdarkly-cpp-server-redis-source-v2.1.3'
   rockspec:
     description: 'The rockspec file for the server-side SDK.'
     required: true

--- a/.github/actions/install-cpp-sdk-redis/action.yml
+++ b/.github/actions/install-cpp-sdk-redis/action.yml
@@ -4,7 +4,7 @@ inputs:
     version:
         required: true
         description: "Version of the C++ SDK with Redis Source."
-        default: "launchdarkly-cpp-server-redis-source-v2.1.2"
+        default: "launchdarkly-cpp-server-redis-source-v2.1.3"
     path:
       description: "Where to download the SDK."
       default: "cpp-sdk"

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -29,7 +29,7 @@ on:
         description: "Version of the C++ Server-side SDK."
         required: false
         type: string
-        default: 'launchdarkly-cpp-server-redis-source-v2.1.0'
+        default: 'launchdarkly-cpp-server-redis-source-v2.1.3'
   workflow_call:
     inputs:
       package:
@@ -49,7 +49,7 @@ env:
   PACKAGE: ${{ inputs.package == null && 'launchdarkly-server-sdk' || inputs.package }}
   VERSION: ${{ inputs.version == null && '' || inputs.version }}
   LUA_VERSION: ${{ inputs.lua-version == null && '5.3' || inputs.lua-version }}
-  CPP_SDK_VERSION: ${{ inputs.cpp-sdk-version == null && 'launchdarkly-cpp-server-redis-source-v2.1.0' || inputs.cpp-sdk-version }}
+  CPP_SDK_VERSION: ${{ inputs.cpp-sdk-version == null && 'launchdarkly-cpp-server-redis-source-v2.1.3' || inputs.cpp-sdk-version }}
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                            | Notes                                      |
 |--------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.3.2](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.3.2)              | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.1.2](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.2) | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.3.3](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.3.3)              | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.1.3](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.3) | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -13,7 +13,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
      apt-get update && \
      apt-get install -y boost1.81
 
-RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.2/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
+RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.3/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
     mkdir ./cpp-sdk && \
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
     rm /tmp/sdk.zip

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -15,7 +15,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
 
 
 RUN mkdir cpp-sdk-libs
-RUN git clone --branch launchdarkly-cpp-server-v3.3.2 https://github.com/launchdarkly/cpp-sdks.git && \
+RUN git clone --branch launchdarkly-cpp-server-v3.3.3 https://github.com/launchdarkly/cpp-sdks.git && \
     cd cpp-sdks && \
     mkdir build-dynamic && \
     cd build-dynamic && \


### PR DESCRIPTION
This version change enables inline contexts for feature events, as well
as anonymous attribute redaction.
