### PR TITLE
ci: add hello-debian example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           docker build -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
       - name: Run ${{ matrix.name }} container in foreground
         run: |
-          docker run -it --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
+          docker run --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
       - name: Verify output
         run: |
           grep -F "is false for this user" logs.txt || (echo "Expected false evaluation!" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["hello-haproxy", "hello-nginx"]
+        name: ["hello-haproxy", "hello-nginx", "hello-debian"]
     env:
       LD_SDK_KEY: foo
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
           rockspec: ${{ matrix.package }}
 
 
-  examples:
+  web-server-examples:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        name: ["hello-haproxy", "hello-nginx", "hello-debian"]
+        name: ["hello-haproxy", "hello-nginx"]
     env:
       LD_SDK_KEY: foo
     steps:
@@ -65,3 +65,23 @@ jobs:
       - name: Stop ${{ matrix.name }} container
         run: |
           docker stop ${{ matrix.name }}
+
+  plain-lua-examples:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ "hello-debian"]
+    env:
+      LD_SDK_KEY: foo
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build ${{ matrix.name }} image
+        run: |
+          docker build -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
+      - name: Run ${{ matrix.name }} container in foreground
+        run: |
+          docker run -it --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
+      - name: Verify output
+        run: |
+          grep -F "is false for this user" logs.txt || (echo "Expected false evaluation!" && exit 1)

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -39,28 +39,12 @@ COPY launchdarkly-server-sdk.c .
 # The example expects to find the env-helper script up one directory, so preserve that structure
 # when copying. The purpose of env-helper is to allow the flag key & SDK keys to be injected via
 # environment variable (LD_SDK_KEY and LD_FLAG_KEY).
-COPY ./examples/hello-lua-server-debian/hello.lua hello-debian/
+COPY ./examples/hello-debian/hello.lua hello-debian/
 COPY ./examples/env-helper env-helper
 
 
 RUN luarocks make launchdarkly-server-sdk-${VERSION}-0.rockspec LD_DIR=./cpp-sdk-libs
 
-# The strategy for this Docker example is to download the C++ SDK release artifacts and use those instead of compiling
-# from source. This is for example/CI purposes only; generally it's better to build from source to ensure all libraries
-# are compatible.
-#
-# Since we require a newer version of boost than is available in Ubuntu 22.04, we grab it from a PPA (mhier/libboost-latest).
-#
-# The SDK dynamic libs expect the boost libs to follow a specific naming convention, which isn't what
-# the libraries from the PPA follow ('-mt' suffix is added to indicate the libraries are built with multithreading support enabled.)
-#
-# It's not 100% clear if these libraries are multithread enabled (build logs in the PPA seem to indicate it),
-# but even so, the C++ SDK is single-threaded.
-#
-# To workaround, add symlinks with the expected names.
-RUN cd /usr/lib/x86_64-linux-gnu && \
-   ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
-   ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0
 
 ENV LD_LIBRARY_PATH=../cpp-sdk-libs/lib
 ENTRYPOINT ["lua", "hello-debian/hello.lua"]

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -45,6 +45,5 @@ COPY ./examples/env-helper env-helper
 
 RUN luarocks make launchdarkly-server-sdk-${VERSION}-0.rockspec LD_DIR=./cpp-sdk-libs
 
-
 ENV LD_LIBRARY_PATH=../cpp-sdk-libs/lib
 ENTRYPOINT ["lua", "hello-debian/hello.lua"]

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -1,0 +1,66 @@
+FROM debian:bookworm
+
+# {{ x-release-please-start-version }}
+ARG VERSION=2.1.0
+# {{ x-release-please-end }}
+
+# For unknown reasons, it appears that boost.json and boost.url aren't included in the
+# libboost-all package.
+
+RUN apt-get update && apt-get install -y \
+    git netbase curl libssl-dev libssl3 apt-transport-https ca-certificates \
+    software-properties-common \
+    cmake ninja-build build-essential \
+    libboost1.81-all-dev libboost-json1.81-dev libboost-url1.81-dev \
+    luarocks
+
+
+RUN mkdir cpp-sdk-libs
+RUN git clone --branch launchdarkly-cpp-server-v3.3.3 https://github.com/launchdarkly/cpp-sdks.git && \
+    cd cpp-sdks && \
+    mkdir build-dynamic && \
+    cd build-dynamic && \
+    cmake -GNinja \
+        -DLD_BUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        -DLD_BUILD_SHARED_LIBS=ON \
+        -DLD_DYNAMIC_LINK_OPENSSL=ON .. && \
+    cmake --build . --target launchdarkly-cpp-server && \
+    cmake --install . --prefix=../../cpp-sdk-libs
+
+
+
+RUN mkdir hello-debian
+
+# The source .c file and the rockspec are needed to compile the LuaRock.
+COPY launchdarkly-server-sdk-${VERSION}-0.rockspec .
+COPY launchdarkly-server-sdk.c .
+
+# The example expects to find the env-helper script up one directory, so preserve that structure
+# when copying. The purpose of env-helper is to allow the flag key & SDK keys to be injected via
+# environment variable (LD_SDK_KEY and LD_FLAG_KEY).
+COPY ./examples/hello-lua-server-debian/hello.lua hello-debian/
+COPY ./examples/env-helper env-helper
+
+
+RUN luarocks make launchdarkly-server-sdk-${VERSION}-0.rockspec LD_DIR=./cpp-sdk-libs
+
+# The strategy for this Docker example is to download the C++ SDK release artifacts and use those instead of compiling
+# from source. This is for example/CI purposes only; generally it's better to build from source to ensure all libraries
+# are compatible.
+#
+# Since we require a newer version of boost than is available in Ubuntu 22.04, we grab it from a PPA (mhier/libboost-latest).
+#
+# The SDK dynamic libs expect the boost libs to follow a specific naming convention, which isn't what
+# the libraries from the PPA follow ('-mt' suffix is added to indicate the libraries are built with multithreading support enabled.)
+#
+# It's not 100% clear if these libraries are multithread enabled (build logs in the PPA seem to indicate it),
+# but even so, the C++ SDK is single-threaded.
+#
+# To workaround, add symlinks with the expected names.
+RUN cd /usr/lib/x86_64-linux-gnu && \
+   ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
+   ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0
+
+ENV LD_LIBRARY_PATH=../cpp-sdk-libs/lib:$LD_LIBRARY_PATH
+ENTRYPOINT ["lua", "hello-debian/hello.lua"]

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -62,5 +62,5 @@ RUN cd /usr/lib/x86_64-linux-gnu && \
    ln -s libboost_json.so.1.81.0 libboost_json-mt-x64.so.1.81.0 && \
    ln -s libboost_url.so.1.81.0 libboost_url-mt-x64.so.1.81.0
 
-ENV LD_LIBRARY_PATH=../cpp-sdk-libs/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=../cpp-sdk-libs/lib
 ENTRYPOINT ["lua", "hello-debian/hello.lua"]

--- a/examples/hello-debian/README.md
+++ b/examples/hello-debian/README.md
@@ -4,7 +4,8 @@ We've built a minimal dockerized example of using the Lua SDK within a Debian Bo
 
 ## Build instructions
 
-1. On the command line from the **root** of the repo, build the image from this directory with `docker build -t hello-debian -f ./examples/hello-debian/Dockerfile .`.
+1. On the command line from the **root** of the repo, build the Docker image:
+`docker build -t hello-debian -f ./examples/hello-debian/Dockerfile .`.
 2. Run the demo with
     ```bash
     docker run --rm --name hello-debian --env LD_SDK_KEY="my-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-debian

--- a/examples/hello-debian/README.md
+++ b/examples/hello-debian/README.md
@@ -1,16 +1,16 @@
-# LaunchDarkly Lua server-side SDK basic example
+# LaunchDarkly Lua server-side SDK Debian Bookworm example
 
-First, modify `hello.lua` to inject your SDK key and boolean-type feature flag key.
+We've built a minimal dockerized example of using the Lua SDK within a Debian Bookworm Docker container. 
 
-Then, use the Lua interpreter to run `hello.lua`:
-```bash
-lua hello.lua
-```
+## Build instructions
 
-If you'd rather use environment variables to specify the SDK key or flag key, set `LD_SDK_KEY` or `LD_FLAG_KEY`.
-```bash
-LD_SDK_KEY=my-sdk-key LD_FLAG_KEY=my-boolean-flag lua hello.lua
-```
+1. On the command line from the **root** of the repo, build the image from this directory with `docker build -t hello-debian -f ./examples/hello-debian/Dockerfile .`.
+2. Run the demo with
+    ```bash
+    docker run --rm --name hello-debian --env LD_SDK_KEY="my-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-debian
+    ```
+3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LD_FLAG_KEY` should be a boolean-type flag in your environment. If you don't pass 
+`LD_FLAG_KEY`, then the default flag key `my-boolean-flag` will be used.
 
-The program should output:
+You should receive the message:
 > Feature flag is <true/false> for this user context

--- a/examples/hello-debian/README.md
+++ b/examples/hello-debian/README.md
@@ -1,0 +1,16 @@
+# LaunchDarkly Lua server-side SDK basic example
+
+First, modify `hello.lua` to inject your SDK key and boolean-type feature flag key.
+
+Then, use the Lua interpreter to run `hello.lua`:
+```bash
+lua hello.lua
+```
+
+If you'd rather use environment variables to specify the SDK key or flag key, set `LD_SDK_KEY` or `LD_FLAG_KEY`.
+```bash
+LD_SDK_KEY=my-sdk-key LD_FLAG_KEY=my-boolean-flag lua hello.lua
+```
+
+The program should output:
+> Feature flag is <true/false> for this user context

--- a/examples/hello-debian/hello.lua
+++ b/examples/hello-debian/hello.lua
@@ -8,20 +8,7 @@ local MY_SDK_KEY = ""
 local MY_FLAG_KEY = "my-boolean-flag"
 
 
-local config = {
-    offline = false,
-    logging = {
-        basic = {
-            level = "debug"
-        },
-    },
-    events = {
-        enabled = false,
-    },
-    dataSystem = {
-        enabled = true,
-    },
-}
+local config = {}
 
 local sdk_key = get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY)
 local client = ld.clientInit(sdk_key, 1000, config)

--- a/examples/hello-debian/hello.lua
+++ b/examples/hello-debian/hello.lua
@@ -1,0 +1,38 @@
+local ld = require("launchdarkly_server_sdk")
+local get_from_env_or_default = dofile("../env-helper/get_from_env_or_default.lua")
+
+-- Set MY_SDK_KEY to your LaunchDarkly SDK key.
+local MY_SDK_KEY = ""
+
+-- Set MY_FLAG_KEY to the boolean-type feature flag key you want to evaluate.
+local MY_FLAG_KEY = "my-boolean-flag"
+
+
+local config = {
+    offline = false,
+    logging = {
+        basic = {
+            level = "debug"
+        },
+    },
+    events = {
+        enabled = false,
+    },
+    dataSystem = {
+        enabled = true,
+    },
+}
+
+local sdk_key = get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY)
+local client = ld.clientInit(sdk_key, 1000, config)
+
+local user = ld.makeContext({
+    user = {
+        key = "example-user-key",
+        name = "Sandy"
+    }
+})
+
+local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
+local value = client:boolVariation(user, flag_key, false)
+print("Feature flag ".. flag_key .." is "..tostring(value).." for this user context")

--- a/scripts/get-cpp-sdk-locally.sh
+++ b/scripts/get-cpp-sdk-locally.sh
@@ -6,7 +6,7 @@
 # Locally, it's more convenient to built the C++ SDK from source - to be able to switch branches,
 # change built options, etc.
 
-# Usage: ./scripts/build-cpp-server.sh <tag>
+# Usage: ./scripts/get-cpp-sdk-locally.sh <tag>
 # If no tag is supplied, it uses 'main'.
 #
 # The SDK headers/libs are installed in ./cpp-sdks/build/INSTALL.


### PR DESCRIPTION
Adds an example that runs in a `debian:bookworm` container. 