### PR TITLE
ci: use common definition of C++ versions

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -5,10 +5,9 @@ inputs:
     description: 'Version of Lua to use for building and testing.'
     required: false
     default: '5.3'
-  cpp-sdk-version:
-    description: 'Version of the C++ Server-side SDK to use for building and testing.'
+  cpp-sdk-redis-version:
+    description: 'Version of the C++ Server-side SDK with Redis Source to use for building and testing.'
     required: false
-    default: 'launchdarkly-cpp-server-redis-source-v2.1.3'
   rockspec:
     description: 'The rockspec file for the server-side SDK.'
     required: true
@@ -16,6 +15,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get C++ Versions
+      id: cpp-versions
+      uses: ./.github/actions/cpp-versions
     - name: Install Lua
       uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e
       with:
@@ -31,7 +33,7 @@ runs:
     - name: Install CPP SDK
       uses: ./.github/actions/install-cpp-sdk-redis
       with:
-          version: ${{ inputs.cpp-sdk-version }}
+          version: ${{ inputs.cpp-sdk-redis-version }}
           path: cpp-sdk
 
     - name: Build Package

--- a/.github/actions/cpp-versions/action.yml
+++ b/.github/actions/cpp-versions/action.yml
@@ -1,0 +1,24 @@
+# The following chunk of yml pulls two C++ sdk version numbers out of a file and
+# makes them available to the other actions/workflows in a convenient fashion.
+# This allows us to easily bump the version numbers in one place, instead of multiple yml files.
+name: C++ Versions
+description: Foo
+outputs:
+  sdk:
+    description: 'The version of the C++ Server-side SDK.'
+    value: ${{ steps.cpp-versions.outputs.sdk }}
+  redis_source:
+    description: 'The version of the C++ Server-side SDK with Redis Source.'
+    value: ${{ steps.cpp-versions.outputs.redis_source }}
+runs:
+  using: composite
+  steps:
+      - name: Set C++ Versions
+        id: cpp-versions
+        shell: bash
+        run:  cat ./.github/variables/cpp-sdk-versions.env > $GITHUB_OUTPUT
+      - name: Display C++ Versions
+        shell: bash
+        run: |
+          echo "${{ format('C++ Server SDK v{0}', steps.cpp-versions.outputs.sdk) }}"
+          echo "${{ format('C++ Server SDK Redis Source v{0}', steps.cpp-versions.outputs.redis_source) }}"

--- a/.github/actions/install-cpp-sdk-redis/action.yml
+++ b/.github/actions/install-cpp-sdk-redis/action.yml
@@ -4,7 +4,6 @@ inputs:
     version:
         required: true
         description: "Version of the C++ SDK with Redis Source."
-        default: "launchdarkly-cpp-server-redis-source-v2.1.3"
     path:
       description: "Where to download the SDK."
       default: "cpp-sdk"
@@ -12,13 +11,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get Default C++ Versions
+      id: cpp-versions
+      uses: ./.github/actions/cpp-versions
     - name: Download C++ Server-side SDK with Redis Source
       uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51
       id: download-cpp-sdk
       with:
           repository: "launchdarkly/cpp-sdks"
           latest: false
-          tag: ${{ inputs.version }}
+          tag: ${{ format('launchdarkly-cpp-server-redis-source-v{0}', inputs.version || steps.cpp-versions.outputs.redis_source) }}
           fileName: linux-gcc-x64-dynamic.zip
           out-file-path: ${{ inputs.path }}
           extract: true

--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.4.0
-redis_source=2.1.7
+sdk=3.3.3
+redis_source=2.1.3

--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,0 +1,2 @@
+sdk=3.4.0
+redis_source=2.1.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,14 @@ jobs:
       LD_SDK_KEY: foo
     steps:
       - uses: actions/checkout@v4
+      - name: Get C++ Versions
+        id: cpp-versions
+        uses: ./.github/actions/cpp-versions
       - name: Build ${{ matrix.name }} image
         run: |
-          docker build -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
+          docker build \
+          --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
+          -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
       - name: Run ${{ matrix.name }} container in background
         run: |
           docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }}
@@ -76,9 +81,14 @@ jobs:
       LD_SDK_KEY: foo
     steps:
       - uses: actions/checkout@v4
+      - name: Get C++ Versions
+        id: cpp-versions
+        uses: ./.github/actions/cpp-versions
       - name: Build ${{ matrix.name }} image
         run: |
-          docker build -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
+          docker build \
+          --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
+          -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
       - name: Run ${{ matrix.name }} container in foreground
         run: |
           docker run --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -29,7 +29,6 @@ on:
         description: "Version of the C++ Server-side SDK."
         required: false
         type: string
-        default: 'launchdarkly-cpp-server-redis-source-v2.1.3'
   workflow_call:
     inputs:
       package:
@@ -49,7 +48,6 @@ env:
   PACKAGE: ${{ inputs.package == null && 'launchdarkly-server-sdk' || inputs.package }}
   VERSION: ${{ inputs.version == null && '' || inputs.version }}
   LUA_VERSION: ${{ inputs.lua-version == null && '5.3' || inputs.lua-version }}
-  CPP_SDK_VERSION: ${{ inputs.cpp-sdk-version == null && 'launchdarkly-cpp-server-redis-source-v2.1.3' || inputs.cpp-sdk-version }}
 jobs:
   install:
     runs-on: ubuntu-latest
@@ -74,7 +72,7 @@ jobs:
       - name: Install CPP SDK
         uses: ./.github/actions/install-cpp-sdk-redis
         with:
-          version: ${{ env.CPP_SDK_VERSION }}
+          version: ${{ inputs.cpp-sdk-version }}
           path: cpp-sdk
 
       - name: Install Package

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,6 +4,8 @@ FROM debian:bookworm
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
+ARG CPP_SDK_VERSION=3.3.3
+
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.
 
@@ -16,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 
 
 RUN mkdir cpp-sdk-libs
-RUN git clone --branch launchdarkly-cpp-server-v3.3.3 https://github.com/launchdarkly/cpp-sdks.git && \
+RUN git clone --branch launchdarkly-cpp-server-v${CPP_SDK_VERSION} https://github.com/launchdarkly/cpp-sdks.git && \
     cd cpp-sdks && \
     mkdir build-dynamic && \
     cd build-dynamic && \

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
+ARG CPP_SDK_VERSION=3.3.3
+
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \
     haproxy apt-transport-https ca-certificates \
@@ -13,7 +15,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
      apt-get update && \
      apt-get install -y boost1.81
 
-RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v3.3.3/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
+RUN curl https://github.com/launchdarkly/cpp-sdks/releases/download/launchdarkly-cpp-server-v${CPP_SDK_VERSION}/linux-gcc-x64-dynamic.zip -L -o /tmp/sdk.zip && \
     mkdir ./cpp-sdk && \
     unzip /tmp/sdk.zip -d ./cpp-sdk && \
     rm /tmp/sdk.zip

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -4,6 +4,8 @@ FROM openresty/openresty:jammy
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
+ARG CPP_SDK_VERSION=3.3.3
+
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \
     software-properties-common \
@@ -15,7 +17,7 @@ RUN add-apt-repository ppa:mhier/libboost-latest && \
 
 
 RUN mkdir cpp-sdk-libs
-RUN git clone --branch launchdarkly-cpp-server-v3.3.3 https://github.com/launchdarkly/cpp-sdks.git && \
+RUN git clone --branch launchdarkly-cpp-server-v${CPP_SDK_VERSION} https://github.com/launchdarkly/cpp-sdks.git && \
     cd cpp-sdks && \
     mkdir build-dynamic && \
     cd build-dynamic && \


### PR DESCRIPTION
This consolidates some of the places we need to specify C++ version numbers into a single `cpp-sdk-versions.env` file.

This is a similar approach to Relay Proxy. 

Updating this file will update:
1. CI unit tests
2. Docker example tests 

But it won't update the versions found in README or in the Docker files themselves (as they have default values for the new build arg I've introduced.)

We need to consider the testing strategy going forward. Should we test a min version, and then also a "current" version? And if so, is that current going to float somehow (like using github's releases API to grab the latest), or be pinned to the latest explicitly (via a workflow, or Renovate or something.)