### PR TITLE
ci: update examples to latest spec

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -58,6 +58,10 @@ runs:
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
 
+    - name: Copy get_from_env to directory above this
+      shell: bash
+      run: |
+        cp -r ./examples/env-helper ../env-helper
     - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
       if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -57,6 +57,12 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
+    - name: Make a temporary script to run lua
+      shell: bash
+      run: |
+        echo "#!/bin/bash" > run_lua.sh
+        echo "cd ./examples/hello-lua-server && lua hello.lua" >> run_lua.sh
+        chmod +x run_lua.sh
     - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
       if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'
@@ -67,4 +73,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: cd ./examples/hello-lua-server
+        command: ./run_lua.sh

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       run: |
         cp -r ./examples/env-helper ../env-helper
-    - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+    - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
       if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'
       env:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -67,6 +67,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: |
-          cd ./examples/hello-lua-server
-          lua hello.lua
+        command: lua ./examples/hello-lua-server/hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -58,6 +58,7 @@ runs:
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
     - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+      if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'
       env:
         # Needed because boost isn't installed in default system paths, which is

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -67,4 +67,6 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: cd ./examples/hello-lua-server && lua hello.lua
+        command: |
+          cd ./examples/hello-lua-server
+          lua hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -11,6 +11,9 @@ inputs:
   rockspec:
     description: 'The rockspec file for the server-side SDK.'
     required: true
+  aws-arn:
+    description: 'The AWS role ARN to use for verifying the example output'
+    required: true
 
 runs:
   using: composite
@@ -54,16 +57,14 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
-    - name: Run hello-lua-server example
-      if: ${{ !contains(inputs.lua-version, 'jit') }}
-      shell: bash
-      run: |
-        cd ./examples/hello-lua-server
-        lua hello.lua | tee output.txt
-        grep -F "is false for this user" output.txt || (echo "Expected false evaluation!" && exit 1)
+    - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+      name: 'Verify hello-lua-server example'
       env:
-        LD_SDK_KEY: "fake-sdk-key"
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects.
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
+      with:
+        use_server_key: true
+        role_arn: ${{ inputs.aws-arn }}
+        command: cd ./examples/hello-lua-server && lua hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -67,4 +67,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: lua ./examples/hello-lua-server/hello.lua
+        command: cd ./examples/hello-lua-server && lua hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -64,8 +64,7 @@ runs:
         # Needed because boost isn't installed in default system paths, which is
         # what the C++ Server-side SDK shared object expects.
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
-        LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: cd ./examples/hello-lua-server && lua hello.lua
+        command: cd ./examples/hello-lua-server

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -68,4 +68,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: "set +e && cd examples/hello-lua-server && lua hello.lua"
+        command: cd examples/hello-lua-server;lua hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -57,12 +57,7 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
-    - name: Make a temporary script to run lua
-      shell: bash
-      run: |
-        echo "#!/bin/bash" > run_lua.sh
-        echo "cd ./examples/hello-lua-server && lua hello.lua" >> run_lua.sh
-        chmod +x run_lua.sh
+
     - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
       if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'
@@ -73,4 +68,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: ./run_lua.sh
+        command: "set +e && cd examples/hello-lua-server && lua hello.lua"

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -57,23 +57,11 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
-    - name: SANITY CHECK
-      if: ${{ !contains(inputs.lua-version, 'jit') }}
-      shell: bash
-      run: |
-        cd ./examples/hello-lua-server
-        lua hello.lua
-      env:
-        LAUNCHDARKLY_SDK_KEY: "fake-sdk-key"
-        # Needed because boost isn't installed in default system paths, which is
-        # what the C++ Server-side SDK shared object expects.
-        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
-
     - name: Copy get_from_env to directory above this
       shell: bash
       run: |
         cp -r ./examples/env-helper ../env-helper
-    - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
+    - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
       if: ${{ !contains(inputs.lua-version, 'jit') }}
       name: 'Verify hello-lua-server example'
       env:

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -68,4 +68,4 @@ runs:
       with:
         use_server_key: true
         role_arn: ${{ inputs.aws-arn }}
-        command: cd examples/hello-lua-server;lua hello.lua
+        command: lua ./examples/hello-lua-server/hello.lua

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -57,6 +57,17 @@ runs:
         LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib;./cpp-sdk/build-dynamic/release/lib
         LUA_INTERPRETER: ${{ contains(inputs.lua-version, 'jit') && 'luajit' || 'lua' }}
 
+    - name: SANITY CHECK
+      if: ${{ !contains(inputs.lua-version, 'jit') }}
+      shell: bash
+      run: |
+        cd ./examples/hello-lua-server
+        lua hello.lua
+      env:
+        LAUNCHDARKLY_SDK_KEY: "fake-sdk-key"
+        # Needed because boost isn't installed in default system paths, which is
+        # what the C++ Server-side SDK shared object expects.
+        LD_LIBRARY_PATH: ${{ steps.install-boost.outputs.BOOST_ROOT }}/lib
 
     - name: Copy get_from_env to directory above this
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
   linux-build:
     needs: rockspecs
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,8 @@ jobs:
 
   web-server-examples:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -58,12 +61,7 @@ jobs:
           docker build \
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
-      - name: Run ${{ matrix.name }} container in background
-        run: |
-          docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }}
-      - name: Evaluate feature flag
-        run: |
-          curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
+
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:
@@ -80,6 +78,8 @@ jobs:
 
   plain-lua-examples:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
+            set +e
             docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
             --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
             --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
@@ -107,6 +108,7 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
+            set +e 
             docker run \
             --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY"  \
             --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           lua-version: ${{ matrix.version }}
           rockspec: ${{ matrix.package }}
-          aws-arn: ${{ secrets.AWS_ROLE_ARN_EXAMPLES }}
+          aws-arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
 
 
   web-server-examples:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,18 @@ jobs:
       - name: Evaluate feature flag
         run: |
           curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
-      - name: Stop ${{ matrix.name }} container
-        run: |
-          docker stop ${{ matrix.name }}
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN }}
-          command: cat response.txt
+          command: |
+            docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }}
+            curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
+            cat response.txt
+      - name: Stop ${{ matrix.name }} container
+        run: |
+          docker stop ${{ matrix.name }}
 
 
   plain-lua-examples:
@@ -91,12 +94,11 @@ jobs:
           docker build \
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
-      - name: Run ${{ matrix.name }} container in foreground
-        run: |
-          docker run --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN }}
-          command: cat logs.txt
+          command: |
+            docker run --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
+            cat logs.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,11 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
-            set +e
             docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
             --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
             --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
             launchdarkly:${{ matrix.name }}
-            curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
-            cat response.txt
+            curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123
       - name: Stop ${{ matrix.name }} container
         run: |
           docker stop ${{ matrix.name }}
@@ -108,9 +106,7 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
-            set +e 
             docker run \
             --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY"  \
             --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
-            launchdarkly:${{ matrix.name }} > logs.txt
-            cat logs.txt
+            launchdarkly:${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,12 @@ jobs:
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
 
-      - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
-            cat foo.bar
-            exit 1
             docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
                       --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
                       --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
@@ -103,7 +101,7 @@ jobs:
           docker build \
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
-      - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         name: ["hello-haproxy", "hello-nginx"]
-    env:
-      LD_SDK_KEY: foo
     steps:
       - uses: actions/checkout@v4
       - name: Get C++ Versions
@@ -62,7 +60,7 @@ jobs:
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
       - name: Run ${{ matrix.name }} container in background
         run: |
-          docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }}
+          docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }}
       - name: Evaluate feature flag
         run: |
           curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
@@ -83,8 +81,6 @@ jobs:
       fail-fast: false
       matrix:
         name: [ "hello-debian"]
-    env:
-      LD_SDK_KEY: foo
     steps:
       - uses: actions/checkout@v4
       - name: Get C++ Versions
@@ -97,7 +93,7 @@ jobs:
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
       - name: Run ${{ matrix.name }} container in foreground
         run: |
-          docker run --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
+          docker run --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         name: 'Verify ${{ matrix.name}} example output'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,18 @@ jobs:
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
 
-      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
-          command: echo "feature flag evaluates to true"
-      - run: |
-          docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
+          command: |
+            docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
                       --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
                       --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
                       launchdarkly:${{ matrix.name }}
                       curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123
+
       - name: Stop ${{ matrix.name }} container
         run: |
           docker stop ${{ matrix.name }}
@@ -101,7 +101,7 @@ jobs:
           docker build \
           --build-arg="CPP_SDK_VERSION=${{ steps.cpp-versions.outputs.sdk }}" \
           -t launchdarkly:${{ matrix.name }} -f ./examples/${{ matrix.name }}/Dockerfile .
-      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@c47c497d4d2a9d662699d48828be060db274d333
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
+            cat foo.bar
+            exit 1
             docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
                       --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
                       --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,16 @@ jobs:
       - name: Evaluate feature flag
         run: |
           curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
-          grep -F "is false for this user" response.txt || (echo "Expected false evaluation!" && exit 1)
       - name: Stop ${{ matrix.name }} container
         run: |
           docker stop ${{ matrix.name }}
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+        name: 'Verify ${{ matrix.name}} example output'
+        with:
+          use_server_key: true
+          role_arn: ${{ vars.AWS_ROLE_ARN }}
+          command: cat response.txt
+
 
   plain-lua-examples:
     runs-on: ubuntu-latest
@@ -92,6 +98,9 @@ jobs:
       - name: Run ${{ matrix.name }} container in foreground
         run: |
           docker run --env LD_SDK_KEY="$LD_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
-      - name: Verify output
-        run: |
-          grep -F "is false for this user" logs.txt || (echo "Expected false evaluation!" && exit 1)
+      - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
+        name: 'Verify ${{ matrix.name}} example output'
+        with:
+          use_server_key: true
+          role_arn: ${{ vars.AWS_ROLE_ARN }}
+          command: cat logs.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           lua-version: ${{ matrix.version }}
           rockspec: ${{ matrix.package }}
+          aws-arn: ${{ secrets.AWS_ROLE_ARN_EXAMPLES }}
 
 
   web-server-examples:
@@ -66,7 +67,7 @@ jobs:
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
-          role_arn: ${{ vars.AWS_ROLE_ARN }}
+          role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
             docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }}
             curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
@@ -98,7 +99,7 @@ jobs:
         name: 'Verify ${{ matrix.name}} example output'
         with:
           use_server_key: true
-          role_arn: ${{ vars.AWS_ROLE_ARN }}
+          role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
             docker run --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
             cat logs.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,13 @@ jobs:
         with:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
-          command: |
-            docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
-            --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
-            --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
-            launchdarkly:${{ matrix.name }}
-            curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123
+          command: echo "feature flag evaluates to true"
+      - run: |
+          docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
+                      --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
+                      --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
+                      launchdarkly:${{ matrix.name }}
+                      curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123
       - name: Stop ${{ matrix.name }} container
         run: |
           docker stop ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,10 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
-            docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }}
+            docker run -dit --rm --name ${{ matrix.name }} -p 8123:80 \
+            --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" \
+            --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
+            launchdarkly:${{ matrix.name }}
             curl --retry 5 --retry-all-errors --retry-delay 1 -s -v http://localhost:8123 | tee response.txt
             cat response.txt
       - name: Stop ${{ matrix.name }} container
@@ -104,5 +107,8 @@ jobs:
           use_server_key: true
           role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
           command: |
-            docker run --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY" launchdarkly:${{ matrix.name }} > logs.txt
+            docker run \
+            --env LAUNCHDARKLY_SDK_KEY="$LAUNCHDARKLY_SDK_KEY"  \
+            --env LAUNCHDARKLY_FLAG_KEY="$LAUNCHDARKLY_FLAG_KEY" \
+            launchdarkly:${{ matrix.name }} > logs.txt
             cat logs.txt

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -40,7 +40,7 @@ COPY launchdarkly-server-sdk.c .
 
 # The example expects to find the env-helper script up one directory, so preserve that structure
 # when copying. The purpose of env-helper is to allow the flag key & SDK keys to be injected via
-# environment variable (LD_SDK_KEY and LD_FLAG_KEY).
+# environment variable (LAUNCHDARKLY_SDK_KEY and LAUNCHDARKLY_FLAG_KEY).
 COPY ./examples/hello-debian/hello.lua hello-debian/
 COPY ./examples/env-helper env-helper
 

--- a/examples/hello-debian/README.md
+++ b/examples/hello-debian/README.md
@@ -14,4 +14,4 @@ We've built a minimal dockerized example of using the Lua SDK within a Debian Bo
 `LD_FLAG_KEY`, then the default flag key `my-boolean-flag` will be used.
 
 You should receive the message:
-> Feature flag is <true/false> for this user context
+> The (flag key) feature flag evaluates to (true/false).

--- a/examples/hello-debian/README.md
+++ b/examples/hello-debian/README.md
@@ -8,10 +8,10 @@ We've built a minimal dockerized example of using the Lua SDK within a Debian Bo
 `docker build -t hello-debian -f ./examples/hello-debian/Dockerfile .`.
 2. Run the demo with
     ```bash
-    docker run --rm --name hello-debian --env LD_SDK_KEY="my-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-debian
+    docker run --rm --name hello-debian --env LAUNCHDARKLY_SDK_KEY="my-sdk-key" --env LAUNCHDARKLY_FLAG_KEY="my-boolean-flag" hello-debian
     ```
-3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LD_FLAG_KEY` should be a boolean-type flag in your environment. If you don't pass 
-`LD_FLAG_KEY`, then the default flag key `my-boolean-flag` will be used.
+3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LAUNCHDARKLY_FLAG_KEY` should be a boolean-type flag in your environment. If you don't pass 
+`LAUNCHDARKLY_FLAG_KEY`, then the default flag key `my-boolean-flag` will be used.
 
 You should receive the message:
 > The (flag key) feature flag evaluates to (true/false).

--- a/examples/hello-debian/hello.lua
+++ b/examples/hello-debian/hello.lua
@@ -22,4 +22,4 @@ local user = ld.makeContext({
 
 local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
 local value = client:boolVariation(user, flag_key, false)
-print("Feature flag ".. flag_key .." is "..tostring(value).." for this user context")
+print("The ".. flag_key .." feature flag evaluates to "..tostring(value)..".")

--- a/examples/hello-debian/hello.lua
+++ b/examples/hello-debian/hello.lua
@@ -10,7 +10,7 @@ local MY_FLAG_KEY = "my-boolean-flag"
 
 local config = {}
 
-local sdk_key = get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY)
+local sdk_key = get_from_env_or_default("LAUNCHDARKLY_SDK_KEY", MY_SDK_KEY)
 local client = ld.clientInit(sdk_key, 1000, config)
 
 local user = ld.makeContext({
@@ -20,6 +20,6 @@ local user = ld.makeContext({
     }
 })
 
-local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
+local flag_key = get_from_env_or_default("LAUNCHDARKLY_FLAG_KEY", MY_FLAG_KEY)
 local value = client:boolVariation(user, flag_key, false)
 print("The ".. flag_key .." feature flag evaluates to "..tostring(value)..".")

--- a/examples/hello-debian/hello.lua
+++ b/examples/hello-debian/hello.lua
@@ -5,7 +5,7 @@ local get_from_env_or_default = dofile("../env-helper/get_from_env_or_default.lu
 local MY_SDK_KEY = ""
 
 -- Set MY_FLAG_KEY to the boolean-type feature flag key you want to evaluate.
-local MY_FLAG_KEY = "my-boolean-flag"
+local MY_FLAG_KEY = ""
 
 
 local config = {}

--- a/examples/hello-haproxy/README.md
+++ b/examples/hello-haproxy/README.md
@@ -7,9 +7,9 @@ We've built a minimal dockerized example of using the Lua SDK with [HAProxy](htt
 1. On the command line from the **root** of the repo, build the image from this directory with `docker build -t hello-haproxy -f ./examples/hello-haproxy/Dockerfile .`.
 2. Run the demo with:  
     ```bash
-    docker run -it --rm --name hello-haproxy -p 8123:8123 --env LD_SDK_KEY="my-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-haproxy
+    docker run -it --rm --name hello-haproxy -p 8123:8123 --env LAUNCHDARKLY_SDK_KEY="my-sdk-key" --env LAUNCHDARKLY_FLAG_KEY="my-boolean-flag" hello-haproxy
     ```
-3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LD_FLAG_KEY` should be a boolean-type flag in your environment.
+3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LAUNCHDARKLY_FLAG_KEY` should be a boolean-type flag in your environment.
 4. Open `localhost:8123` in your browser. Toggle the flag on to see a change in the page (refresh the page.)
 
 You should receive the message: 

--- a/examples/hello-haproxy/README.md
+++ b/examples/hello-haproxy/README.md
@@ -13,4 +13,4 @@ We've built a minimal dockerized example of using the Lua SDK with [HAProxy](htt
 4. Open `localhost:8123` in your browser. Toggle the flag on to see a change in the page (refresh the page.)
 
 You should receive the message: 
-> Feature flag is <true/false> for this user context
+> The (flag key) feature flag evaluates to (true/false).

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -26,9 +26,6 @@ core.register_service("launchdarkly", "http", function(applet)
         }
     })
 
-    if client:boolVariation(user, flag_key, false) then
-        applet:send("<p>Feature flag " .. flag_key .. " is true for this user context</p>")
-    else
-        applet:send("<p>Feature flag " .. flag_key .. " is false for this user context</p>")
-    end
+    local flag_value = client:boolVariation(user, flag_key, false)
+    applet:send("<p>The " .. flag_key .. " feature flag evaluates to " .. tostring(flag_value) .. ".</p>")
 end)

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -11,10 +11,10 @@ local MY_SDK_KEY = ""
 local MY_FLAG_KEY = "my-boolean-flag"
 
 local config = {}
-local sdk_key = get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY)
+local sdk_key = get_from_env_or_default("LAUNCHDARKLY_SDK_KEY", MY_SDK_KEY)
 local client = ld.clientInit(sdk_key, 1000, config)
 
-local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
+local flag_key = get_from_env_or_default("LAUNCHDARKLY_FLAG_KEY", MY_FLAG_KEY)
 
 core.register_service("launchdarkly", "http", function(applet)
     applet:start_response()

--- a/examples/hello-haproxy/service.lua
+++ b/examples/hello-haproxy/service.lua
@@ -8,7 +8,7 @@ local get_from_env_or_default = require("get_from_env_or_default")
 local MY_SDK_KEY = ""
 
 -- Set MY_FLAG_KEY to the boolean-type feature flag key you want to evaluate.
-local MY_FLAG_KEY = "my-boolean-flag"
+local MY_FLAG_KEY = ""
 
 local config = {}
 local sdk_key = get_from_env_or_default("LAUNCHDARKLY_SDK_KEY", MY_SDK_KEY)

--- a/examples/hello-lua-server/README.md
+++ b/examples/hello-lua-server/README.md
@@ -7,9 +7,9 @@ Then, use the Lua interpreter to run `hello.lua`:
 lua hello.lua
 ```
 
-If you'd rather use environment variables to specify the SDK key or flag key, set `LD_SDK_KEY` or `LD_FLAG_KEY`.
+If you'd rather use environment variables to specify the SDK key or flag key, set `LAUNCHDARKLY_SDK_KEY` or `LAUNCHDARKLY_FLAG_KEY`.
 ```bash
-LD_SDK_KEY=my-sdk-key LD_FLAG_KEY=my-boolean-flag lua hello.lua
+LAUNCHDARKLY_SDK_KEY=my-sdk-key LAUNCHDARKLY_FLAG_KEY=my-boolean-flag lua hello.lua
 ```
 
 The program should output:

--- a/examples/hello-lua-server/README.md
+++ b/examples/hello-lua-server/README.md
@@ -13,4 +13,4 @@ LD_SDK_KEY=my-sdk-key LD_FLAG_KEY=my-boolean-flag lua hello.lua
 ```
 
 The program should output:
-> Feature flag is <true/false> for this user context
+> The (flag key) feature flag evaluates to (true/false).

--- a/examples/hello-lua-server/hello.lua
+++ b/examples/hello-lua-server/hello.lua
@@ -22,4 +22,4 @@ local user = ld.makeContext({
 
 local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
 local value = client:boolVariation(user, flag_key, false)
-print("Feature flag ".. flag_key .." is "..tostring(value).." for this user context")
+print("The ".. flag_key .." feature flag evaluates to "..tostring(value)..".")

--- a/examples/hello-lua-server/hello.lua
+++ b/examples/hello-lua-server/hello.lua
@@ -10,7 +10,7 @@ local MY_FLAG_KEY = "my-boolean-flag"
 
 local config = {}
 
-local sdk_key = get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY)
+local sdk_key = get_from_env_or_default("LAUNCHDARKLY_SDK_KEY", MY_SDK_KEY)
 local client = ld.clientInit(sdk_key, 1000, config)
 
 local user = ld.makeContext({
@@ -20,6 +20,6 @@ local user = ld.makeContext({
     }
 })
 
-local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
+local flag_key = get_from_env_or_default("LAUNCHDARKLY_FLAG_KEY", MY_FLAG_KEY)
 local value = client:boolVariation(user, flag_key, false)
 print("The ".. flag_key .." feature flag evaluates to "..tostring(value)..".")

--- a/examples/hello-lua-server/hello.lua
+++ b/examples/hello-lua-server/hello.lua
@@ -5,7 +5,7 @@ local get_from_env_or_default = dofile("../env-helper/get_from_env_or_default.lu
 local MY_SDK_KEY = ""
 
 -- Set MY_FLAG_KEY to the boolean-type feature flag key you want to evaluate.
-local MY_FLAG_KEY = "my-boolean-flag"
+local MY_FLAG_KEY = ""
 
 
 local config = {}

--- a/examples/hello-nginx/README.md
+++ b/examples/hello-nginx/README.md
@@ -13,4 +13,4 @@ We've built a minimal dockerized example of using the Lua SDK with [OpenResty NG
 4. Open `localhost:8123` in your browser. Toggle the flag on to see a change in the page (refresh the page.)
 
 You should receive the message:
-> Feature flag is <true/false> for this user context
+> The (flag key) feature flag evaluates to (true/false).

--- a/examples/hello-nginx/README.md
+++ b/examples/hello-nginx/README.md
@@ -7,9 +7,9 @@ We've built a minimal dockerized example of using the Lua SDK with [OpenResty NG
 1. On the command line from the **root** of the repo, build the image from this directory with `docker build -t hello-nginx -f ./examples/hello-nginx/Dockerfile .`.
 2. Run the demo with
     ```bash
-    docker run --rm --name hello-nginx -p 8123:80 --env LD_SDK_KEY="my-sdk-key" --env LD_FLAG_KEY="my-boolean-flag" hello-nginx
+    docker run --rm --name hello-nginx -p 8123:80 --env LAUNCHDARKLY_SDK_KEY="my-sdk-key" --env LAUNCHDARKLY_FLAG_KEY="my-boolean-flag" hello-nginx
     ```
-3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LD_FLAG_KEY` should be a boolean-type flag in your environment.
+3. **Note:** the SDK key and flag key are passed with environment variables into the container. The `LAUNCHDARKLY_FLAG_KEY` should be a boolean-type flag in your environment.
 4. Open `localhost:8123` in your browser. Toggle the flag on to see a change in the page (refresh the page.)
 
 You should receive the message:

--- a/examples/hello-nginx/nginx.conf
+++ b/examples/hello-nginx/nginx.conf
@@ -2,8 +2,8 @@ events {
     worker_connections 1024;
 }
 
-env LD_SDK_KEY;
-env LD_FLAG_KEY;
+env LAUNCHDARKLY_SDK_KEY;
+env LAUNCHDARKLY_FLAG_KEY;
 
 http {
     resolver 8.8.8.8;
@@ -24,7 +24,7 @@ http {
 
 
                 -- Set MY_FLAG_KEY to the feature flag key you want to evaluate. To specify the flag key as
-                -- an environment variable instead, set LD_FLAG_KEY using '--env LD_FLAG_KEY=my-boolean-flag-key'
+                -- an environment variable instead, set LAUNCHDARKLY_FLAG_KEY using '--env LAUNCHDARKLY_FLAG_KEY=my-boolean-flag-key'
                 -- as a 'docker run' argument.
 
                 local MY_FLAG_KEY = "my-boolean-flag"
@@ -36,7 +36,7 @@ http {
                     }
                 })
 
-                local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
+                local flag_key = get_from_env_or_default("LAUNCHDARKLY_FLAG_KEY", MY_FLAG_KEY)
                 local flag_value = client:boolVariation(user, flag_key, false)
                 ngx.say("<p>The " .. flag_key .. " feature flag evaluates to " .. tostring(flag_value) .. ".</p>")
             }

--- a/examples/hello-nginx/nginx.conf
+++ b/examples/hello-nginx/nginx.conf
@@ -27,7 +27,7 @@ http {
                 -- an environment variable instead, set LAUNCHDARKLY_FLAG_KEY using '--env LAUNCHDARKLY_FLAG_KEY=my-boolean-flag-key'
                 -- as a 'docker run' argument.
 
-                local MY_FLAG_KEY = "my-boolean-flag"
+                local MY_FLAG_KEY = ""
 
                 local user = ld.makeContext({
                     user =  {

--- a/examples/hello-nginx/nginx.conf
+++ b/examples/hello-nginx/nginx.conf
@@ -37,11 +37,8 @@ http {
                 })
 
                 local flag_key = get_from_env_or_default("LD_FLAG_KEY", MY_FLAG_KEY)
-                if client:boolVariation(user, flag_key, false) then
-                    ngx.say("<p>Feature flag " .. flag_key .. " is true for this user context</p>")
-                else
-                    ngx.say("<p>Feature flag " .. flag_key .. " is false for this user context</p>")
-                end
+                local flag_value = client:boolVariation(user, flag_key, false)
+                ngx.say("<p>The " .. flag_key .. " feature flag evaluates to " .. tostring(flag_value) .. ".</p>")
             }
         }
     }

--- a/examples/hello-nginx/shared.lua
+++ b/examples/hello-nginx/shared.lua
@@ -3,9 +3,9 @@ local os = require("os")
 local get_from_env_or_default = require("get_from_env_or_default")
 
 -- Set MY_SDK_KEY to your LaunchDarkly SDK key. To specify the SDK key as an environment variable instead,
--- set LD_SDK_KEY using '--env LD_SDK_KEY=my-sdk-key' as a 'docker run' argument.
+-- set LAUNCHDARKLY_SDK_KEY using '--env LAUNCHDARKLY_SDK_KEY=my-sdk-key' as a 'docker run' argument.
 local MY_SDK_KEY = ""
 
 local config = {}
 
-return ld.clientInit(get_from_env_or_default("LD_SDK_KEY", MY_SDK_KEY), 1000, config)
+return ld.clientInit(get_from_env_or_default("LAUNCHDARKLY_SDK_KEY", MY_SDK_KEY), 1000, config)


### PR DESCRIPTION
Updates all Lua examples to use the verify-hello-app action, and the correct environment variable names. 

This allows the flag key/SDK key to be changed as necessary without any hardcoding. 