### PR TITLE
fix(deps): bump C++ Server to 3.5.2

### DIFF
--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.3.3
-redis_source=2.1.3
+sdk=3.5.2
+redis_source=2.1.10

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.3.3
+ARG CPP_SDK_VERSION=3.5.2
 
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.3.3
+ARG CPP_SDK_VERSION=3.5.2
 
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -4,7 +4,7 @@ FROM openresty/openresty:jammy
 ARG VERSION=2.1.0
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.3.3
+ARG CPP_SDK_VERSION=3.5.2
 
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \


### PR DESCRIPTION
This pulls in a bugfix which significantly improves the logging experience when given an incorrect SDK key.