### PR TITLE
fix: Bump SDK and redis source

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -27,6 +27,8 @@ runs:
         luaVersion: ${{ inputs.lua-version }}
     - name: Install LuaRocks
       uses: luarocks/gh-actions-luarocks@8acd6db166a0162c375fa8647a0350fbec46940e
+      with:
+        luarocksVersion: "3.12.0"
     - name: Install Boost
       id: install-boost
       uses: MarkusJx/install-boost@v2.4.4

--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.8.0
-redis_source=2.1.16
+sdk=3.9.0
+redis_source=2.1.19

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5
+        with:
+          luarocksVersion: "3.12.0"
 
       - name: Install Boost
         id: install-boost

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                              | Notes                                      |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.8.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.8.0)                | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.1.16](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.16) | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.9.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.9.0)                | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.1.19](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.19) | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG VERSION=2.1.2
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.8.0
+ARG CPP_SDK_VERSION=3.9.0
 
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.2
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.8.0
+ARG CPP_SDK_VERSION=3.9.0
 
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -7,7 +7,7 @@ FROM openresty/openresty:1.21.4.1-0-jammy
 ARG VERSION=2.1.2
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.8.0
+ARG CPP_SDK_VERSION=3.9.0
 
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Bump launchdarkly-cpp-server to v3.9.0
fix: Bump launchdarkly-cpp-server-redis-source to v2.1.19
END_COMMIT_OVERRIDE
