### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -22,16 +22,16 @@ runs:
       id: cpp-versions
       uses: ./.github/actions/cpp-versions
     - name: Install Lua
-      uses: luarocks/gh-actions-lua@c1e8c4a5fa64ac5f6467ea35d8b59fb5a167232e
+      uses: luarocks/gh-actions-lua@c1e8c4a5fa64ac5f6467ea35d8b59fb5a167232e # c1e8c4a5fa64ac5f6467ea35d8b59fb5a167232e
       with:
         luaVersion: ${{ inputs.lua-version }}
     - name: Install LuaRocks
-      uses: luarocks/gh-actions-luarocks@8acd6db166a0162c375fa8647a0350fbec46940e
+      uses: luarocks/gh-actions-luarocks@8acd6db166a0162c375fa8647a0350fbec46940e # 8acd6db166a0162c375fa8647a0350fbec46940e
       with:
         luarocksVersion: "3.12.0"
     - name: Install Boost
       id: install-boost
-      uses: MarkusJx/install-boost@v2.4.4
+      uses: MarkusJx/install-boost@3039450bb3dd2e8630d1cf10ec39cb1da3054bbd # v2.4.4
       with:
         boost_version: 1.81.0
         platform_version: "22.04"

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -55,18 +55,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Lua
-        uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e
+        uses: leafo/gh-actions-lua@35bcb06abec04ec87df82e08caa84d545348536e # 35bcb06abec04ec87df82e08caa84d545348536e
         with:
           luaVersion: ${{ env.LUA_VERSION }}
 
       - name: Install LuaRocks
-        uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5
+        uses: leafo/gh-actions-luarocks@e65774a6386cb4f24e293dca7fc4ff89165b64c5 # e65774a6386cb4f24e293dca7fc4ff89165b64c5
         with:
           luarocksVersion: "3.12.0"
 
       - name: Install Boost
         id: install-boost
-        uses: MarkusJx/install-boost@v2.4.4
+        uses: MarkusJx/install-boost@3039450bb3dd2e8630d1cf10ec39cb1da3054bbd # v2.4.4
         with:
           boost_version: 1.81.0
           platform_version: "22.04"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr_branch_name: ${{ steps.release.outputs.prs_created == 'true' && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that pin existing third-party GitHub Actions to immutable SHAs to reduce supply-chain risk; behavior should remain the same aside from consuming the exact referenced commits.
> 
> **Overview**
> Pins several third-party GitHub Actions used by CI and release workflows to full commit SHAs (and annotates them with their previous tags/SHAs) instead of floating version tags.
> 
> This updates the shared CI composite action and the `install-lua-sdk` and `release-please` workflows, including `MarkusJx/install-boost` and `google-github-actions/release-please-action`, to use immutable references for more reproducible and secure builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e0cd2e0a47167d62a28ff8089a48467999dc13b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->