### PR TITLE
test: add fork PR CI behavior probe

### DIFF
--- a/ci-fork-pr-behavior-probe.txt
+++ b/ci-fork-pr-behavior-probe.txt
@@ -1,0 +1,3 @@
+Harmless CI behavior probe for fork pull request workflow validation.
+
+This file intentionally does not read, print, or request any secrets.


### PR DESCRIPTION
This draft PR is a harmless CI behavior probe.

It adds only a plain text file and intentionally does not read, print, request, or exfiltrate any secrets. The purpose is to observe how the public fork `pull_request` workflow behaves for a non-member fork PR.