### PR TITLE
chore: update C++ server-side SDK Redis Source from 2.1.19 to 2.2.2

### DIFF
--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
 sdk=3.10.1
-redis_source=2.1.19
+redis_source=2.2.2


### PR DESCRIPTION
## Summary

Updates the C++ Server-side SDK Redis Source dependency used in CI from 2.1.19 to 2.2.2 in `.github/variables/cpp-sdk-versions.env`.

Notable changes in the Redis Source between these versions:
- 2.2.0: Updated to hiredis 1.3
- 2.2.2: Bumped internal C++ server SDK dependency to 3.10.1

The primary C++ Server SDK dependency (`sdk=3.10.1`) is already at the latest stable version.

Link to Devin session: https://app.devin.ai/sessions/6147113664cc4bd6bf0d1aff7d50fbda
Requested by: @kinyoklion