### PR TITLE
feat: build with LuaJIT 2.1 and test against latest C++ server-side SDK

### DIFF
--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.10.1
-redis_source=2.1.19
+sdk=3.12.0
+redis_source=2.3.1

--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.13.0
-redis_source=2.4.0
+sdk=3.13.1
+redis_source=2.4.1

--- a/.github/variables/cpp-sdk-versions.env
+++ b/.github/variables/cpp-sdk-versions.env
@@ -1,2 +1,2 @@
-sdk=3.12.0
-redis_source=2.3.1
+sdk=3.13.0
+redis_source=2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["5.1", "5.2", "5.3", "luajit-2.0.5"]
+        version: ["5.1", "5.2", "5.3", "luajit-2.1"]
         package: ${{ fromJSON(needs.rockspecs.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/install-lua-sdk.yml
+++ b/.github/workflows/install-lua-sdk.yml
@@ -23,7 +23,7 @@ on:
           - '5.1'
           - '5.2'
           - '5.3'
-          - 'luajit-2.0.5'
+          - 'luajit-2.1'
         default: '5.3'
       cpp-sdk-version:
         description: "Version of the C++ Server-side SDK."

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                              | Notes                                      |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.12.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.12.0)               | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.3.1](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.3.1)    | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.13.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.13.0)               | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.4.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.4.0)    | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                              | Notes                                      |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.13.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.13.0)              | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.4.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.4.0)   | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.9.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.9.0)                | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.1.19](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.19) | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                              | Notes                                      |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.9.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.9.0)                | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.1.19](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.1.19) | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.12.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.12.0)               | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.3.1](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.3.1)    | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LaunchDarkly overview
 Supported Lua versions
 -----------
 
-This version of the LaunchDarkly SDK is known to be compatible with the Lua 5.1-5.3 interpreter, and LuaJIT 2.0.5.
+This version of the LaunchDarkly SDK is known to be compatible with the Lua 5.1-5.3 interpreter, and LuaJIT 2.1.
 
 Supported C++ server-side SDK versions
 -----------
@@ -26,8 +26,8 @@ If Redis support is desired, then it optionally depends on the C++ server-side S
 
 | Dependency                     | Minimum Version                                                                                              | Notes                                      |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| C++ Server-Side SDK            | [3.13.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.13.0)               | Required dependency.                       |
-| C++ Server-Side SDK with Redis | [2.4.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.4.0)    | Optional, if using Redis as a data source. |
+| C++ Server-Side SDK            | [3.13.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.13.0)              | Required dependency.                       |
+| C++ Server-Side SDK with Redis | [2.4.0](https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-redis-source-v2.4.0)   | Optional, if using Redis as a data source. |
 
 
 3rd Party Dependencies

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.10.1
+ARG CPP_SDK_VERSION=3.12.0
 
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.12.0
+ARG CPP_SDK_VERSION=3.13.0
 
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.

--- a/examples/hello-debian/Dockerfile
+++ b/examples/hello-debian/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.13.0
+ARG CPP_SDK_VERSION=3.13.1
 
 # For unknown reasons, it appears that boost.json and boost.url aren't included in the
 # libboost-all package.

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.10.1
+ARG CPP_SDK_VERSION=3.12.0
 
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.12.0
+ARG CPP_SDK_VERSION=3.13.0
 
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \

--- a/examples/hello-haproxy/Dockerfile
+++ b/examples/hello-haproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.13.0
+ARG CPP_SDK_VERSION=3.13.1
 
 RUN apt-get update && apt-get install -y \
     curl luarocks lua5.3 lua5.3-dev \

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -7,7 +7,7 @@ FROM openresty/openresty:1.21.4.1-0-jammy
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.10.1
+ARG CPP_SDK_VERSION=3.12.0
 
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -7,7 +7,7 @@ FROM openresty/openresty:1.21.4.1-0-jammy
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.13.0
+ARG CPP_SDK_VERSION=3.13.1
 
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \

--- a/examples/hello-nginx/Dockerfile
+++ b/examples/hello-nginx/Dockerfile
@@ -7,7 +7,7 @@ FROM openresty/openresty:1.21.4.1-0-jammy
 ARG VERSION=2.1.3
 # {{ x-release-please-end }}
 
-ARG CPP_SDK_VERSION=3.12.0
+ARG CPP_SDK_VERSION=3.13.0
 
 RUN apt-get update && apt-get install -y \
     git netbase curl libssl-dev apt-transport-https ca-certificates \

--- a/launchdarkly-server-sdk-redis.c
+++ b/launchdarkly-server-sdk-redis.c
@@ -56,24 +56,6 @@ static const struct luaL_Reg launchdarkly_functions[] = {
     { NULL, NULL}
 };
 
-#if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
-/*
-** Adapted from Lua 5.2.0
-*/
-static void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
-  luaL_checkstack(L, nup+1, "too many upvalues");
-  for (; l->name != NULL; l++) {  /* fill the table with given functions */
-    int i;
-    lua_pushstring(L, l->name);
-    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
-      lua_pushvalue(L, -(nup+1));
-    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
-    lua_settable(L, -(nup + 3));
-  }
-  lua_pop(L, nup);  /* remove upvalues */
-}
-#endif
-
 int
 luaopen_launchdarkly_server_sdk_redis(lua_State *const l)
 {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Supersedes #123 (which only updated Redis Source to 2.2.2).

**Describe the solution you've provided**

Builds and tests against current toolchain and SDK versions, without changing what this SDK *requires*:

- `launchdarkly-server-sdk-redis.c`: removed the static `luaL_setfuncs` Lua 5.1 shim. It was never called, and LuaJIT 2.1's `lauxlib.h` declares `luaL_setfuncs` non-static, so the shim broke compilation there (`static declaration of 'luaL_setfuncs' follows non-static declaration`). `launchdarkly-server-sdk.c` has its own correctly-named `ld_luaL_setfuncs` and is unaffected.
- CI LuaJIT matrix `luajit-2.0.5` → `luajit-2.1`. `luarocks/gh-actions-lua` clones `--branch v2.0.5` from `luajit/luajit` and that branch/tag no longer exists upstream (only `v2.0`, `v2.1`, `master` remain), so those jobs failed at the *Install Lua* step. `luajit-2.1` is LuaJIT's current rolling release. README's LuaJIT compatibility note updated to match.
- CI / example build versions: C++ Server-side SDK `3.10.1` → `3.13.1`, Redis Source `2.1.19` → `2.4.1` (both current latest).
- The README minimum-version table stays at `3.9.0` / `2.1.19` — the Lua SDK still works with those; working with the latest is not the same as requiring it.

Files changed:
- `launchdarkly-server-sdk-redis.c`
- `.github/variables/cpp-sdk-versions.env` — central version config used by CI
- `examples/hello-haproxy/Dockerfile`, `examples/hello-nginx/Dockerfile`, `examples/hello-debian/Dockerfile` — default `CPP_SDK_VERSION` ARG for local builds
- `.github/workflows/ci.yml`, `.github/workflows/install-lua-sdk.yml` — LuaJIT version built and tested
- `README.md` — LuaJIT compatibility note

**How to test it**

CI builds and tests both rockspecs on Lua 5.1/5.2/5.3 and LuaJIT 2.1 against the C++ SDK 3.13.1 / Redis Source 2.4.1 artifacts, and builds the `hello-haproxy`, `hello-nginx`, and `hello-debian` example images. Also verified locally on Lua 5.1: `luarocks make` of both rockspecs against the prebuilt redis-source v2.4.1 `linux-gcc-x64-dynamic` artifact, `test.lua` 20/20 passing, and `examples/hello-lua-server/hello.lua` run against a real server-side SDK key (client init, data sync, flag evaluation).

**Additional context**

No deprecated APIs are used by the examples (`clientInit`, `makeContext`, `boolVariation`), and the C++ 3.13.1 bindings compile without warnings.

Link to Devin session: https://app.devin.ai/sessions/85ca4fcc915e4e38bdee004d3d493824
Requested by: @kinyoklion

Link to Devin session: https://app.devin.ai/sessions/1a367c31818a4fa6a1d33eb65a7b2331
Requested by: @jsonbailey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **CI and toolchain alignment** for current LuaJIT and C++ artifacts: the matrix and install workflow now use **LuaJIT 2.1** instead of `luajit-2.0.5` (upstream tag/branch no longer available), and **`.github/variables/cpp-sdk-versions.env`** plus example Dockerfiles default to C++ server SDK **3.13.1** and Redis Source **2.4.1**. The README’s supported LuaJIT line is updated to **2.1**.
> 
> **LuaJIT compile fix** in `launchdarkly-server-sdk-redis.c`: drops an unused static **`luaL_setfuncs`** Lua 5.1 shim that conflicted with LuaJIT 2.1’s non-static declaration in `lauxlib.h`. The main SDK module keeps its separate **`ld_luaL_setfuncs`** helper unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501b641c7a8bc2400769c33a7daaf73cd1e5c582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->