### PR TITLE
ci: grant contents write permission to update-release-pr job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to push rockspec updates to the release PR branch
     steps:
       - uses: actions/checkout@v4
       - name: Update launchdarkly-server-sdk rockspec


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Failing run: https://github.com/launchdarkly/lua-server-sdk/actions/runs/31441985892/job/93628882965

**Describe the solution you've provided**

The `update-release-pr` job in `.github/workflows/release-please.yml` declared no `permissions:` block, so its `GITHUB_TOKEN` was read-only. The rockspec rename/version bump commit was created successfully, but pushing it to the release-please branch failed:

```
remote: Permission to launchdarkly/lua-server-sdk.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/launchdarkly/lua-server-sdk/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```

Adding `permissions: contents: write` to that job matches what the sibling `release-please` job already declares, and lets the composite `update-versions` action push its commit.

**Describe alternatives you've considered**

Using a PAT / app token instead of `GITHUB_TOKEN`. Not needed here — the default token is sufficient once the job has write scope. (Note that commits pushed with `GITHUB_TOKEN` do not trigger further workflow runs, which is already the existing behavior expectation for this job.)

**Additional context**

Single-line workflow change; no SDK code affected.


Link to Devin session: https://app.devin.ai/sessions/f93d057c29fd4a0c85554d10f9715457
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The **`update-release-pr`** job in `release-please.yml` now declares **`permissions: contents: write`**, aligning it with the sibling **`release-please`** job.
> 
> Without write scope, the default `GITHUB_TOKEN` stayed read-only and pushes from the **`update-versions`** composite action failed with a 403 after rockspec commits were created locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618dfa4c8d0057b94de66b9b14766e64d4d40363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->